### PR TITLE
Add ability to run tests with docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,14 +39,14 @@ before_install:
 before_script:
   - sudo service mysql stop # By default travis has a MySQL service running, turn it off to prevent conflicts
   - sudo service postgresql stop # By default travis has a Postgres service running, turn it off to prevent conflicts
-  - docker-compose up -d
+  - docker-compose -f nakadi-docker-compose.yml up -d
 
 script:
  - sbt clean coverage test coverageReport
  - sbt -DTOKEN=test ++$TRAVIS_SCALA_VERSION "test"
 
 after_script:
-  - docker-compose down
+  - docker-compose -f nakadi-docker-compose.yml down
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,14 @@ libraryDependencies ++= Seq(
   "org.specs2"                 %% "specs2-core"         % "3.8.9" % Test
 )
 
+composeNoBuild := true
+
+enablePlugins(DockerComposePlugin)
+
+testPassUseSpecs2 := true
+
+composeFile := "nakadi-docker-compose.yml"
+
 scalacOptions in Test ++= Seq("-Yrangepos")
 
 homepage := Some(url("https://github.com/zalando-incubator/kanadi"))

--- a/nakadi-docker-compose.yml
+++ b/nakadi-docker-compose.yml
@@ -1,0 +1,46 @@
+version: '2'
+services:
+  nakadi:
+    image: adyach/nakadi-docker:latest
+    ports:
+     - "8080:8080"
+    depends_on:
+     - postgres
+     - zookeeper
+     - kafka
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - NAKADI_OAUTH2_MODE=OFF
+      - NAKADI_ZOOKEEPER_BROKERS=zookeeper:2181
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/local_nakadi_db
+
+  postgres:
+    image: adyach/nakadi-postgres:latest
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: nakadi
+      POSTGRES_PASSWORD: nakadi
+      POSTGRES_DB: local_nakadi_db
+
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:0.10.1.0
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'false'
+      KAFKA_DELETE_TOPIC_ENABLE: 'true'
+      KAFKA_BROKER_ID: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "latest.release")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+
+addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.34")


### PR DESCRIPTION
This PR is about giving an SBT command that will run tests that will automatically start docker-compose then the run the tests and then shut it down. We do this using the https://github.com/Tapad/sbt-docker-compose library

So far things seem to work, however there appears to be a bug in sbt-docker-compose where its not running all specs2 tests, making an issue in upstream to see what can be the cause