### PR TITLE
Specify ExecutionContext on client level

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -325,7 +325,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     implicit
     kanadiHttpConfig: HttpConfig,
     http: HttpExt,
-    materializer: Materializer)
+    materializer: Materializer,
+    executionContext: ExecutionContext)
     extends EventTypesInterface {
   protected val logger: LoggerTakingImplicit[FlowId] = Logger.takingImplicit[FlowId](classOf[EventTypes])
 
@@ -336,7 +337,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return
     */
-  def list()(implicit flowId: FlowId = randomFlowId(), executionContext: ExecutionContext): Future[List[EventType]] = {
+  def list()(implicit flowId: FlowId = randomFlowId()): Future[List[EventType]] = {
     val uri = baseUri_.withPath(baseUri_.path / "event-types")
 
     val baseHeaders = List(RawHeader(`X-Flow-ID`, flowId.value))
@@ -383,8 +384,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return
     */
-  def create(eventType: EventType)(implicit flowId: FlowId = randomFlowId(),
-                                   executionContext: ExecutionContext): Future[Unit] = {
+  def create(eventType: EventType)(implicit flowId: FlowId = randomFlowId()): Future[Unit] = {
     val uri = baseUri_.withPath(baseUri_.path / "event-types")
 
     val baseHeaders = List(RawHeader(`X-Flow-ID`, flowId.value))
@@ -417,8 +417,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return
     */
-  def get(name: EventTypeName)(implicit flowId: FlowId = randomFlowId(),
-                               executionContext: ExecutionContext): Future[Option[EventType]] = {
+  def get(name: EventTypeName)(implicit flowId: FlowId = randomFlowId()): Future[Option[EventType]] = {
     val uri =
       baseUri_.withPath(baseUri_.path / "event-types" / name.name)
 
@@ -457,8 +456,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return
     */
-  def update(name: EventTypeName, eventType: EventType)(implicit flowId: FlowId = randomFlowId(),
-                                                        executionContext: ExecutionContext): Future[Unit] = {
+  def update(name: EventTypeName, eventType: EventType)(implicit flowId: FlowId = randomFlowId()): Future[Unit] = {
     val uri =
       baseUri_.withPath(baseUri_.path / "event-types" / name.name)
 
@@ -497,8 +495,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return
     */
-  def delete(name: EventTypeName)(implicit flowId: FlowId = randomFlowId(),
-                                  executionContext: ExecutionContext): Future[Unit] = {
+  def delete(name: EventTypeName)(implicit flowId: FlowId = randomFlowId()): Future[Unit] = {
     val uri =
       baseUri_.withPath(baseUri_.path / "event-types" / name.name)
 

--- a/src/main/scala/org/zalando/kanadi/api/EventTypesInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypesInterface.scala
@@ -6,17 +6,13 @@ import org.zalando.kanadi.models.EventTypeName
 import scala.concurrent.{ExecutionContext, Future}
 
 trait EventTypesInterface {
-  def list()(implicit flowId: FlowId = randomFlowId(), executionContext: ExecutionContext): Future[List[EventType]]
+  def list()(implicit flowId: FlowId = randomFlowId()): Future[List[EventType]]
 
-  def create(eventType: EventType)(implicit flowId: FlowId = randomFlowId(),
-                                   executionContext: ExecutionContext): Future[Unit]
+  def create(eventType: EventType)(implicit flowId: FlowId = randomFlowId()): Future[Unit]
 
-  def get(name: EventTypeName)(implicit flowId: FlowId = randomFlowId(),
-                               executionContext: ExecutionContext): Future[Option[EventType]]
+  def get(name: EventTypeName)(implicit flowId: FlowId = randomFlowId()): Future[Option[EventType]]
 
-  def update(name: EventTypeName, eventType: EventType)(implicit flowId: FlowId = randomFlowId(),
-                                                        executionContext: ExecutionContext): Future[Unit]
+  def update(name: EventTypeName, eventType: EventType)(implicit flowId: FlowId = randomFlowId()): Future[Unit]
 
-  def delete(name: EventTypeName)(implicit flowId: FlowId = randomFlowId(),
-                                  executionContext: ExecutionContext): Future[Unit]
+  def delete(name: EventTypeName)(implicit flowId: FlowId = randomFlowId()): Future[Unit]
 }

--- a/src/main/scala/org/zalando/kanadi/api/EventsInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventsInterface.scala
@@ -9,7 +9,6 @@ import scala.concurrent.{ExecutionContext, Future}
 trait EventsInterface {
   def publish[T](name: EventTypeName, events: List[Event[T]], fillMetadata: Boolean = true)(
       implicit encoder: Encoder[T],
-      flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      flowId: FlowId = randomFlowId()
   ): Future[Unit]
 }

--- a/src/main/scala/org/zalando/kanadi/api/Registry.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Registry.scala
@@ -16,10 +16,12 @@ import org.zalando.kanadi.models._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvider] = None)(implicit
-                                                                                           kanadiHttpConfig: HttpConfig,
-                                                                                           http: HttpExt,
-                                                                                           materializer: Materializer)
+case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvider] = None)(
+    implicit
+    kanadiHttpConfig: HttpConfig,
+    http: HttpExt,
+    materializer: Materializer,
+    executionContext: ExecutionContext)
     extends RegistryInterface {
   protected val logger: LoggerTakingImplicit[FlowId] = Logger.takingImplicit[FlowId](classOf[Registry])
   private val baseUri_                               = Uri(baseUri.toString)
@@ -29,8 +31,7 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return Returns a list of all enrichment strategies known to Nakadi
     */
-  def enrichmentStrategies(implicit flowId: FlowId = randomFlowId(),
-                           executionContext: ExecutionContext): Future[List[String]] = {
+  def enrichmentStrategies(implicit flowId: FlowId = randomFlowId()): Future[List[String]] = {
     val uri =
       baseUri_.withPath(baseUri_.path / "registry" / "enrichment-strategies")
 
@@ -70,8 +71,7 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
     * @param flowId The flow id of the request, which is written into the logs and passed to called services. Helpful for operational troubleshooting and log analysis.
     * @return Returns a list of all partitioning strategies known to Nakadi
     */
-  def partitionStrategies(implicit flowId: FlowId = randomFlowId(),
-                          executionContext: ExecutionContext): Future[List[PartitionStrategy]] = {
+  def partitionStrategies(implicit flowId: FlowId = randomFlowId()): Future[List[PartitionStrategy]] = {
     val uri =
       baseUri_.withPath(baseUri_.path / "registry" / "partition-strategies")
 

--- a/src/main/scala/org/zalando/kanadi/api/RegistryInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/RegistryInterface.scala
@@ -5,9 +5,7 @@ import org.mdedetrich.webmodels.FlowId
 import scala.concurrent.{ExecutionContext, Future}
 
 trait RegistryInterface {
-  def enrichmentStrategies(implicit flowId: FlowId = randomFlowId(),
-                           executionContext: ExecutionContext): Future[List[String]]
+  def enrichmentStrategies(implicit flowId: FlowId = randomFlowId()): Future[List[String]]
 
-  def partitionStrategies(implicit flowId: FlowId = randomFlowId(),
-                          executionContext: ExecutionContext): Future[List[PartitionStrategy]]
+  def partitionStrategies(implicit flowId: FlowId = randomFlowId()): Future[List[PartitionStrategy]]
 }

--- a/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
@@ -10,48 +10,40 @@ import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 trait SubscriptionsInterface {
-  def create(subscription: Subscription)(implicit flowId: FlowId = randomFlowId(),
-                                         executionContext: ExecutionContext): Future[Subscription]
+  def create(subscription: Subscription)(implicit flowId: FlowId = randomFlowId()): Future[Subscription]
 
   def createIfDoesntExist(subscription: Subscription)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Subscription]
 
   def list(owningApplication: Option[String] = None,
            eventType: Option[List[EventTypeName]] = None,
            limit: Option[Int] = None,
            offset: Option[Int] = None)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[SubscriptionQuery]
 
   def get(subscriptionId: SubscriptionId)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Option[Subscription]]
 
   def delete(subscriptionId: SubscriptionId)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Unit]
 
   def cursors(subscriptionId: SubscriptionId)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Option[SubscriptionCursor]]
 
   def commitCursors(subscriptionId: SubscriptionId,
                     subscriptionCursor: SubscriptionCursor,
                     streamId: StreamId,
                     eventBatch: Boolean)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Option[CommitCursorResponse]]
 
   def resetCursors(subscriptionId: SubscriptionId, subscriptionCursor: Option[SubscriptionCursor] = None)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Boolean]
 
   def eventsStrictUnsafe[T](subscriptionId: SubscriptionId,
@@ -62,8 +54,7 @@ trait SubscriptionsInterface {
                             streamTimeout: Option[FiniteDuration] = None,
                             streamKeepAliveLimit: Option[Int] = None)(
       implicit decoder: Decoder[List[Event[T]]],
-      flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      flowId: FlowId = randomFlowId()
   ): Future[List[SubscriptionEvent[T]]]
 
   def eventsStreamedSource[T](subscriptionId: SubscriptionId,
@@ -75,7 +66,6 @@ trait SubscriptionsInterface {
       implicit
       decoder: Decoder[List[Event[T]]],
       flowId: FlowId,
-      executionContext: ExecutionContext,
       eventStreamSupervisionDecider: Subscriptions.EventStreamSupervisionDecider): Future[Subscriptions.NakadiSource[T]]
 
   def eventsStreamed[T](subscriptionId: SubscriptionId,
@@ -90,7 +80,6 @@ trait SubscriptionsInterface {
                                                                                    UniqueKillSwitch]] = None)(
       implicit decoder: Decoder[List[Event[T]]],
       flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext,
       eventStreamSupervisionDecider: Subscriptions.EventStreamSupervisionDecider
   ): Future[StreamId]
 
@@ -106,7 +95,6 @@ trait SubscriptionsInterface {
                                                                                           UniqueKillSwitch]] = None)(
       implicit decoder: Decoder[List[Event[T]]],
       flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext,
       eventStreamSupervisionDecider: Subscriptions.EventStreamSupervisionDecider
   ): Future[StreamId]
 
@@ -119,13 +107,11 @@ trait SubscriptionsInterface {
       implicit
       decoder: Decoder[List[Event[T]]],
       flowId: FlowId,
-      executionContext: ExecutionContext,
       eventStreamSupervisionDecider: Subscriptions.EventStreamSupervisionDecider): Future[Subscriptions.NakadiSource[T]]
 
   def closeHttpConnection(subscriptionId: SubscriptionId, streamId: StreamId): Boolean
 
   def stats(subscriptionId: SubscriptionId)(
-      implicit flowId: FlowId = randomFlowId(),
-      executionContext: ExecutionContext
+      implicit flowId: FlowId = randomFlowId()
   ): Future[Option[SubscriptionStats]]
 }


### PR DESCRIPTION
This PR specifies the `ExecutionContext` to be put on the client level rather than as every parameter in the method in the client.

As well as making the interfaces simpler, this is required in order to use an akka circuit breaker. The akka circuit breaker instance needs to be shared among all methods in a client and it requires an `ExecutionContext` to instantiate.