### PR TITLE
Add ability to retry on failure of publishing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,20 @@ reconnect after a minute. Note that when you are deploying a new instance of you
 more instances than partitions the above code will handle this situation (when the old instance will terminate
 and disconnect from the stream it will free up some slots, so the new instance will eventually reconnect)
 
+#### Automatically retrying sending of events
+
+Kanadi has a configuration option `kanadi.http-config.failed-publish-event-retry` which allows Kanadi to automatically
+resend events should they fail. The setting can also be set using the environment variable
+`KANADI_HTTP_CONFIG_FAILED_PUBLISH_EVENT_RETRY`. By default this setting is `false` since enabling this can cause
+events to be sent out of order, in other words you shouldn't enable it if you (or your consumers) rely on ordering
+of events. Kanadi will only resend the events which actually failed to send and it will refuse to send
+events which failed due to schema validation (since resending such events is pointless).
+
+Since Nakadi will only fail to publish an event in extreme circumstances (i.e. under heavy load) the retry
+uses an exponential backoff which can be configured with `kanadi.exponential-backoff-config` settings (see 
+`reference.conf` for information on the settings). If reach the maximum number of retries then `Events.publish`
+will fail with the original `Events.Errors.EventValidation` exception.
+
 #### Modifying the akka-stream source
 
 It is possible to modify the underlying akka stream when using `Subscriptions.eventsStreamed` or

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,5 +15,16 @@ kanadi {
     no-empty-slots-cursor-reset-retry-delay = ${?KANADI_HTTP_CONFIG_NO_EMPTY_SLOTS_CURSOR_RESET_RETRY_DELAY}
     server-disconnect-retry-delay = "10 seconds"
     server-disconnect-retry-delay = ${?KANADI_HTTP_CONFIG_SERVER_DISCONNECT_RETRY_DELAY}
+    failed-publish-event-retry = false
+    failed-publish-event-retry = ${?KANADI_HTTP_CONFIG_FAILED_PUBLISH_EVENT_RETRY}
+  }
+
+  exponential-backoff-config {
+    initial-delay = 100 millis
+    initial-delay = ${?KANADI_EXPONENTIAL_BACKOFF_CONFIG_INITIAL_DELAY}
+    backoff-factor = 1.5
+    backoff-factor = ${?KANADI_EXPONENTIAL_BACKOFF_CONFIG_BACKOFF_FACTOR}
+    max-retries = 5
+    max-retries = ${?KANADI_EXPONENTIAL_BACKOFF_CONFIG_MAX_RETRIES}
   }
 }

--- a/src/main/scala/org/zalando/kanadi/Config.scala
+++ b/src/main/scala/org/zalando/kanadi/Config.scala
@@ -3,7 +3,7 @@ package org.zalando.kanadi
 import java.net.URI
 
 import net.ceedubs.ficus.Ficus._
-import org.zalando.kanadi.models.HttpConfig
+import org.zalando.kanadi.models.{ExponentialBackoffConfig, HttpConfig}
 import net.ceedubs.ficus.readers.ArbitraryTypeReader._
 import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
 
@@ -13,4 +13,7 @@ trait Config {
   lazy val nakadiUri: URI = new URI(config.as[String]("kanadi.nakadi.uri"))
 
   implicit lazy val kanadiHttpConfig: HttpConfig = config.as[HttpConfig]("kanadi.http-config")
+
+  implicit lazy val kanadiExponentialBackoffConfig: ExponentialBackoffConfig =
+    config.as[ExponentialBackoffConfig]("kanadi.exponential-backoff-config")
 }

--- a/src/main/scala/org/zalando/kanadi/models/ExponentialBackoffConfig.scala
+++ b/src/main/scala/org/zalando/kanadi/models/ExponentialBackoffConfig.scala
@@ -1,0 +1,12 @@
+package org.zalando.kanadi.models
+
+import scala.concurrent.duration._
+
+final case class ExponentialBackoffConfig(initialDelay: FiniteDuration, backoffFactor: Double, maxRetries: Int) {
+
+  def calculate(retry: Int, interval: FiniteDuration): FiniteDuration =
+    interval * Math.pow(backoffFactor, retry.toDouble) match {
+      case f: FiniteDuration => f
+      case _                 => throw new Exception("Expected FiniteDuration")
+    }
+}

--- a/src/main/scala/org/zalando/kanadi/models/HttpConfig.scala
+++ b/src/main/scala/org/zalando/kanadi/models/HttpConfig.scala
@@ -6,4 +6,5 @@ final case class HttpConfig(censorOAuth2Token: Boolean,
                             singleStringChunkLength: Int,
                             eventListChunkLength: Int,
                             noEmptySlotsCursorResetRetryDelay: FiniteDuration,
-                            serverDisconnectRetryDelay: FiniteDuration)
+                            serverDisconnectRetryDelay: FiniteDuration,
+                            failedPublishEventRetry: Boolean)

--- a/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
@@ -1,0 +1,176 @@
+package org.zalando.kanadi.api
+
+import java.net.URI
+import java.util.UUID
+
+import defaults._
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import io.circe._
+import org.mdedetrich.webmodels.FlowId
+import org.specs2.Specification
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.specification.core.SpecStructure
+import org.zalando.kanadi.Config
+import org.zalando.kanadi.models.{EventTypeName, ExponentialBackoffConfig, HttpConfig}
+
+import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
+import net.ceedubs.ficus.readers.ArbitraryTypeReader._
+import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
+import net.ceedubs.ficus.Ficus._
+import org.zalando.kanadi.api.Events.Errors
+
+class EventPublishRetrySpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+
+  override lazy implicit val kanadiHttpConfig: HttpConfig =
+    config.as[HttpConfig]("kanadi.http-config").copy(failedPublishEventRetry = true)
+
+  override implicit lazy val kanadiExponentialBackoffConfig: ExponentialBackoffConfig =
+    ExponentialBackoffConfig(50 millis, 1.5, 5)
+
+  override def is: SpecStructure =
+    sequential ^
+      s2"""
+    Failed partial events are successfully retried $retryPartialEvents
+    Retry forever and eventually fail $retryForeverAndFail
+  """
+
+  lazy val config = ConfigFactory.load()
+
+  implicit val system       = ActorSystem()
+  implicit val http         = Http()
+  implicit val materializer = ActorMaterializer()
+
+  import scala.util._
+
+  val eventsClient =
+    Events(new URI("http://localhost:8000"), None)
+
+  sealed abstract class State
+
+  object State {
+
+    case object Initial extends State
+
+    case class RetryFailed(failedEvents: List[Event[EventData]]) extends State
+
+  }
+
+  private val TestEvent = "test-event"
+
+  case class EventData(order: Int)
+
+  object EventData {
+    implicit val encoder: Encoder[EventData] = Encoder.forProduct1("order")(x => EventData.unapply(x).get)
+    implicit val decoder: Decoder[EventData] = Decoder.forProduct1("order")(EventData.apply)
+  }
+
+  var state: State = State.Initial
+
+  val events = (1 to 10).map { index =>
+    Event.Business(EventData(index))
+  }.toList
+
+  private def randomSplit[A](list: List[A]) = {
+    val size         = list.size
+    val sizeMinusOne = list.size - 1
+    val index = scala.util.Random.nextInt(size) match {
+      case 0              => 1
+      case `size`         => list.size - 2
+      case `sizeMinusOne` => list.size - 2
+      case s              => s
+    }
+
+    list.splitAt(index)
+  }
+
+  val retryWithFailedEventsPromise = Promise[List[Event[EventData]]]
+  val retryWithFailedEvents        = retryWithFailedEventsPromise.future
+
+  def routes(runForever: Boolean) =
+    pathPrefix("event-types" / TestEvent / "events") {
+      pathEndOrSingleSlash {
+        post {
+          entity(as[List[Event[EventData]]]) { events =>
+            state match {
+              case State.Initial =>
+                val (_, fail) = randomSplit(events)
+                val failedEvents = fail.map { event =>
+                  if (event.data.order == 10)
+                    Events.BatchItemResponse(
+                      event.getMetadata.map(_.eid),
+                      Events.PublishingStatus.Aborted,
+                      Some(Events.Step.Validating),
+                      None
+                    )
+                  else
+                    Events.BatchItemResponse(
+                      event.getMetadata.map(_.eid),
+                      Events.PublishingStatus.Aborted,
+                      Some(Events.Step.Enriching),
+                      None
+                    )
+                }
+
+                state = State.RetryFailed(fail)
+
+                complete((StatusCodes.MultiStatus, failedEvents))
+              case State.RetryFailed(fail) =>
+                if (runForever) {
+                  val failedEvents = fail.map { event =>
+                    Events.BatchItemResponse(
+                      event.getMetadata.map(_.eid),
+                      Events.PublishingStatus.Aborted,
+                      Some(Events.Step.Enriching),
+                      None
+                    )
+                  }
+                  complete((StatusCodes.MultiStatus, failedEvents))
+                } else {
+                  retryWithFailedEventsPromise.complete(Success(fail))
+                  complete(StatusCodes.OK)
+                }
+            }
+          }
+        }
+      }
+    }
+
+  implicit val flowId = FlowId(UUID.randomUUID().toString)
+
+  def retryPartialEvents = {
+    val future = for {
+      bind         <- Http(system).bindAndHandle(routes(false), "localhost", 8000)
+      _            <- eventsClient.publish(EventTypeName(TestEvent), events)
+      failedEvents <- retryWithFailedEvents
+      _            <- bind.terminate(1 minute)
+    } yield failedEvents
+
+    future must not be empty.await(3, 1 minute)
+  }
+
+  def retryForeverAndFail = {
+    val future = for {
+      bind <- Http(system).bindAndHandle(routes(true), "localhost", 8000)
+      _ <- eventsClient.publish(EventTypeName(TestEvent), events).recoverWith {
+            case e => bind.terminate(1 minute).flatMap(_ => Future.failed(e))
+          }
+    } yield ()
+
+    future must throwA[Errors.EventValidation]
+      .like {
+        case e: Errors.EventValidation =>
+          forall(e.batchItemResponse)(event => event.step mustNotEqual Some(Events.Step.Validating))
+      }
+      .await(3, 1 minute)
+
+  }
+
+}


### PR DESCRIPTION
Fixes  #107 

This PR adds the ability (default turned off since it messes with ordering of events) which retries sending of events if they fail. We use exponential backoff algorithm since such a case is likely to happen when Nakadi is already overloaded.
