### PR TITLE
Set to snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 
 sudo: required
+dist: trusty
 
 env:
   - DOCKER_COMPOSE_VERSION=1.21.1

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.4.2"
+version := "0.4.3-SNAPSHOT"


### PR DESCRIPTION
See https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/4 for the `dist:trusty` section

Signed-off-by: Matthew de Detrich <mdedetrich@gmail.com>