### PR TITLE
Support Scala 2.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ services:
 
 scala:
   - 2.11.12
-  - 2.12.8
+  - 2.12.10
+  - 2.13.1
 
 jdk: oraclejdk8
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,23 @@ a year, including handling events from Zalando's main website search.
 
 ### Installation
 
-Kanadi is currently deployed to OSS Sonatype. For Circe 0.11.x use Kanadi 0.4.x
+Kanadi is currently deployed to OSS Sonatype. For Circe 0.12.x use Kanadi 0.5.x (also supports Scala 2.13.x)
 
 ```sbt
 libraryDependencies ++= Seq(
-    "org.zalando" %% "kanadi" % "0.4.1"
+    "org.zalando" %% "kanadi" % "0.5.0"
 )
 ```
 
-Kanadi is currently deployed to OSS Sonatype. For Circe 0.10.x use Kanadi 0.3.x
+For Circe 0.11.x use Kanadi 0.4.x
+
+```sbt
+libraryDependencies ++= Seq(
+    "org.zalando" %% "kanadi" % "0.4.2"
+)
+```
+
+For Circe 0.10.x use Kanadi 0.3.x
 
 ```sbt
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,38 @@
 name := """kanadi"""
 
-val akkaHttpVersion        = "10.1.8"
-val akkaStreamsJsonVersion = "0.3.0"
-val currentScalaVersion    = "2.11.12"
-val enumeratumCirceVersion = "1.5.20"
-val circeVersion           = "0.11.1"
-val akkaVersion            = "2.5.23"
+val akkaHttpVersion                          = "10.1.9"
+val akkaStreamsJsonLatestVersion             = "0.4.0"
+val akkaStreamsJsonOldVersion                = "0.3.0"
+val currentScalaVersion                      = "2.12.10"
+val scala213Version                          = "2.13.1"
+val enumeratumCirceLatestVersion             = "1.5.22"
+val enumeratumCirceOldVersion                = "1.5.20"
+val circeLatestVersion                       = "0.12.3" // for Scala 2.12 and 2.13
+val circeOldVersion                          = "0.11.1" // only for scala 2.11
+val akkaVersion                              = "2.5.26"
+val specs2OldVersion                         = "4.3.4"
+val specs2LatestVersion                      = "4.8.0"
+val heikoseebergerAkkaHttpCirceOldVersion    = "1.25.2"
+val heikoseebergerAkkaHttpCirceLatestVersion = "1.29.1"
+
+def circeVersion(scalaVer: String): String =
+  if (scalaVer.startsWith("2.11")) circeOldVersion else circeLatestVersion
+
+def specs2Version(scalaVer: String): String =
+  if (scalaVer.startsWith("2.11")) specs2OldVersion else specs2LatestVersion
+
+def enumeratumCirceVersion(scalaVer: String): String =
+  if (scalaVer.startsWith("2.11")) enumeratumCirceOldVersion else enumeratumCirceLatestVersion
+
+def akkaStreamsJsonVersion(scalaVer: String): String =
+  if (scalaVer.startsWith("2.11")) akkaStreamsJsonOldVersion else akkaStreamsJsonLatestVersion
+
+def heikoseebergerAkkaHttpCirceVersion(scalaVer: String): String =
+  if (scalaVer.startsWith("2.11")) heikoseebergerAkkaHttpCirceOldVersion else heikoseebergerAkkaHttpCirceLatestVersion
 
 scalaVersion in ThisBuild := currentScalaVersion
 
-crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.12.8")
+crossScalaVersions in ThisBuild := Seq("2.11.11", currentScalaVersion, "2.13.1")
 
 organization := "org.zalando"
 
@@ -32,32 +55,23 @@ scalacOptions ++= Seq(
   "-unchecked",                    // Enable additional warnings where generated code depends on assumptions.
   "-Xcheckinit",                   // Wrap field accessors to throw an exception on uninitialized access.
   //  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-  "-Xfuture",                         // Turn on future language features.
-  "-Xlint:adapted-args",              // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-  "-Xlint:delayedinit-select",        // Selecting member of DelayedInit.
-  "-Xlint:doc-detached",              // A Scaladoc comment appears to be detached from its element.
-  "-Xlint:inaccessible",              // Warn about inaccessible types in method signatures.
-  "-Xlint:infer-any",                 // Warn when a type argument is inferred to be `Any`.
-  "-Xlint:missing-interpolator",      // A string literal appears to be missing an interpolator id.
-  "-Xlint:nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Xlint:nullary-unit",              // Warn when nullary methods return Unit.
-  "-Xlint:option-implicit",           // Option.apply used implicit view.
-  "-Xlint:package-object-classes",    // Class or object defined in package object.
-  "-Xlint:poly-implicit-overload",    // Parameterized overloaded implicit methods are not visible as view bounds.
-  "-Xlint:private-shadow",            // A private field (or class parameter) shadows a superclass field.
-  "-Xlint:stars-align",               // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow",     // A local type parameter shadows a type already in scope.
-  "-Xlint:unsound-match",             // Pattern match may not be typesafe.
+  "-Xfuture",                      // Turn on future language features.
+  "-Xlint:adapted-args",           // Warn if an argument list is modified to match the receiver.
+  "-Xlint:delayedinit-select",     // Selecting member of DelayedInit.
+  "-Xlint:doc-detached",           // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible",           // Warn about inaccessible types in method signatures.
+  "-Xlint:infer-any",              // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:missing-interpolator",   // A string literal appears to be missing an interpolator id.
+  "-Xlint:option-implicit",        // Option.apply used implicit view.
+  "-Xlint:package-object-classes", // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow",         // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align",            // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow",  // A local type parameter shadows a type already in scope.
   //"-Yno-adapted-args", // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-  "-Ypartial-unification",   // Enable partial unification in type constructor inference
-  "-Ywarn-dead-code",        // Warn when dead code is identified.
-  "-Ywarn-inaccessible",     // Warn about inaccessible types in method signatures.
-  "-Ywarn-infer-any",        // Warn when a type argument is inferred to be `Any`.
-  "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Ywarn-nullary-unit",     // Warn when nullary methods return Unit.
-  "-Ywarn-numeric-widen",    // Warn when numerics are widened.
-  "-Ywarn-value-discard"     // Warn when non-Unit expression results are unused.
+  "-Ywarn-dead-code",     // Warn when dead code is identified.
+  "-Ywarn-numeric-widen", // Warn when numerics are widened.
+  "-Ywarn-value-discard"  // Warn when non-Unit expression results are unused.
 )
 
 val flagsFor11 = Seq(
@@ -66,41 +80,74 @@ val flagsFor11 = Seq(
   "-Ywarn-infer-any",
   "-Yclosure-elim",
   "-Ydead-code",
-  "-Xsource:2.12" // required to build case class construction
+  "-Ypartial-unification",
+  "-Ywarn-inaccessible",              // Warn about inaccessible types in method signatures.
+  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+  "-Xlint:unsound-match",             // Pattern match may not be typesafe.
+  "-Ywarn-infer-any",                 // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Xlint:nullary-unit",              // Warn when nullary methods return Unit.
+  "-Xsource:2.12"                     // required to build case class construction
 )
 
 val flagsFor12 = Seq(
   "-Xlint:_",
   "-Ywarn-infer-any",
+  "-Ypartial-unification",
+  "-Ywarn-inaccessible",              // Warn about inaccessible types in method signatures.
+  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+  "-Xlint:unsound-match",             // Pattern match may not be typesafe.
+  "-Ywarn-infer-any",                 // Warn when a type argument is inferred to be `Any`.
+  "-Xlint:nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Xlint:nullary-unit",              // Warn when nullary methods return Unit.
+  "-opt-inline-from:<sources>"
+)
+
+val flagsFor13 = Seq(
+  "-Xlint:_",
   "-opt-inline-from:<sources>"
 )
 
 scalacOptions ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, n)) if n >= 12 =>
+    case Some((2, n)) if n == 13 =>
+      flagsFor13
+    case Some((2, n)) if n == 12 =>
       flagsFor12
     case Some((2, n)) if n == 11 =>
       flagsFor11
   }
 }
 
-libraryDependencies ++= Seq(
-  "com.typesafe.akka"          %% "akka-http"           % akkaHttpVersion,
-  "com.typesafe.akka"          %% "akka-slf4j"          % akkaVersion,
-  "com.typesafe.akka"          %% "akka-stream"         % akkaVersion,
-  "org.mdedetrich"             %% "censored-raw-header" % "0.2.0",
-  "org.mdedetrich"             %% "webmodels"           % "0.5.0",
-  "com.beachape"               %% "enumeratum-circe"    % enumeratumCirceVersion,
-  "io.circe"                   %% "circe-java8"         % circeVersion,
-  "io.circe"                   %% "circe-parser"        % circeVersion,
-  "org.mdedetrich"             %% "akka-stream-circe"   % akkaStreamsJsonVersion,
-  "org.mdedetrich"             %% "akka-http-circe"     % akkaStreamsJsonVersion,
-  "de.heikoseeberger"          %% "akka-http-circe"     % "1.25.2",
-  "com.iheart"                 %% "ficus"               % "1.4.3",
-  "com.typesafe.scala-logging" %% "scala-logging"       % "3.8.0",
-  "ch.qos.logback"             % "logback-classic"      % "1.1.7",
-  "org.specs2"                 %% "specs2-core"         % "3.8.9" % Test
-)
+libraryDependencies ++= {
+  Seq(
+    "com.typesafe.akka"          %% "akka-http"           % akkaHttpVersion,
+    "com.typesafe.akka"          %% "akka-slf4j"          % akkaVersion,
+    "com.typesafe.akka"          %% "akka-stream"         % akkaVersion,
+    "org.mdedetrich"             %% "censored-raw-header" % "0.4.0",
+    "org.mdedetrich"             %% "webmodels"           % "0.6.0",
+    "com.beachape"               %% "enumeratum-circe"    % enumeratumCirceVersion(scalaVersion.value),
+    "io.circe"                   %% "circe-parser"        % circeVersion(scalaVersion.value),
+    "org.mdedetrich"             %% "akka-stream-circe"   % akkaStreamsJsonVersion(scalaVersion.value),
+    "org.mdedetrich"             %% "akka-http-circe"     % akkaStreamsJsonVersion(scalaVersion.value),
+    "de.heikoseeberger"          %% "akka-http-circe"     % heikoseebergerAkkaHttpCirceVersion(scalaVersion.value),
+    "com.iheart"                 %% "ficus"               % "1.4.7",
+    "com.typesafe.scala-logging" %% "scala-logging"       % "3.9.2",
+    "ch.qos.logback"             % "logback-classic"      % "1.1.7",
+    "org.specs2"                 %% "specs2-core"         % specs2Version(scalaVersion.value) % Test
+  ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n == 13 =>
+      Seq(
+        "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0" % Test
+      )
+    case Some((2, n)) if n == 11 =>
+      Seq(
+        "io.circe" %% "circe-java8" % circeVersion(scalaVersion.value)
+      )
+    case _ =>
+      Seq.empty
+  })
+}
 
 scalacOptions in Test ++= Seq("-Yrangepos")
 

--- a/src/main/scala-2.11/org.zalando.kanadi.api/CrossVersionImports.scala
+++ b/src/main/scala-2.11/org.zalando.kanadi.api/CrossVersionImports.scala
@@ -1,0 +1,5 @@
+package org.zalando.kanadi.api
+
+private[this] object CrossVersionImports
+    extends io.circe.java8.time.JavaTimeDecoders
+    with io.circe.java8.time.JavaTimeEncoders

--- a/src/main/scala-2.12/org/zalando/kanadi/api/CrossVersionImports.scala
+++ b/src/main/scala-2.12/org/zalando/kanadi/api/CrossVersionImports.scala
@@ -1,0 +1,3 @@
+package org.zalando.kanadi.api
+
+private[this] object CrossVersionImports

--- a/src/main/scala-2.13/org.zalando.kanadi.api/CrossVersionImports.scala
+++ b/src/main/scala-2.13/org.zalando.kanadi.api/CrossVersionImports.scala
@@ -1,0 +1,3 @@
+package org.zalando.kanadi.api
+
+private[this] object CrossVersionImports

--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -15,7 +15,7 @@ import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import enumeratum._
 import io.circe._
-import io.circe.java8.time._
+import CrossVersionImports._
 import io.circe.syntax._
 import org.mdedetrich.webmodels.{FlowId, OAuth2TokenProvider}
 import org.mdedetrich.webmodels.RequestHeaders.`X-Flow-ID`

--- a/src/main/scala/org/zalando/kanadi/api/Events.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Events.scala
@@ -15,7 +15,7 @@ import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import enumeratum._
 import io.circe.Decoder.Result
-import io.circe.java8.time._
+import CrossVersionImports._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
 import org.mdedetrich.webmodels.{FlowId, OAuth2TokenProvider}

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -19,7 +19,7 @@ import cats.syntax.either._
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import enumeratum._
-import io.circe.java8.time._
+import CrossVersionImports._
 import io.circe.{Decoder, Encoder, JsonObject}
 import io.circe.syntax._
 import org.zalando.kanadi.api.defaults._
@@ -955,7 +955,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
                     string
                       .grouped(kanadiHttpConfig.singleStringChunkLength)
                       .map(ByteString(_))
-                      .to[List])
+                      .toList)
                     .via(Framing.delimiter(ByteString("\n"), Int.MaxValue, allowTruncation = true))
                     .via(combinedJsonParserGraph)
                     .map {
@@ -965,7 +965,7 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
                     .limit(kanadiHttpConfig.eventListChunkLength.toLong)
                     .runWith(Sink.seq)
                 }
-              } yield result.to[List]
+              } yield result.toList
             } else {
               processNotSuccessful(response)
             }

--- a/src/main/scala/org/zalando/kanadi/models/CustomHeaders.scala
+++ b/src/main/scala/org/zalando/kanadi/models/CustomHeaders.scala
@@ -4,5 +4,5 @@ import akka.http.scaladsl.model.headers.RawHeader
 
 final case class CustomHeaders(headers: Map[String, String]) extends AnyVal {
   def toRawHeaders: List[RawHeader] =
-    headers.to[List].map { case (k, v) => RawHeader(k, v) }
+    headers.toList.map { case (k, v) => RawHeader(k, v) }
 }

--- a/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
@@ -1,36 +1,50 @@
+package org.zalando.kanadi
+
 import java.util.UUID
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
+import akka.stream.{ActorMaterializer, Supervision}
 import com.typesafe.config.ConfigFactory
+import io.circe.{Decoder, Encoder}
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
-import org.zalando.kanadi.Config
-import org.zalando.kanadi.api.Subscriptions.{
-  ConnectionClosedCallback,
-  EventCallback,
-  defaultEventStreamSupervisionDecider
-}
+import org.zalando.kanadi.api.Subscriptions.{ConnectionClosedCallback, EventCallback, EventStreamContext}
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
-import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
 import scala.util.Success
 
-class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+final case class SomeBadEvent(firstName: String, lastName: Int, uuid: UUID)
+
+object SomeBadEvent {
+  implicit val someBadEventEncoder: Encoder[SomeBadEvent] =
+    Encoder.forProduct3(
+      "first_name",
+      "last_name",
+      "uuid"
+    )(x => SomeBadEvent.unapply(x).get)
+  implicit val someBadEventDecoder: Decoder[SomeBadEvent] =
+    Decoder.forProduct3(
+      "first_name",
+      "last_name",
+      "uuid"
+    )(SomeBadEvent.apply)
+}
+
+class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
   override def is: SpecStructure = sequential ^ s2"""
+    This test handles when a decoder fails to parse some JSON
     Create Event Type          $createEventType
     Create Subscription events $createSubscription
-    Start streaming            $startStreaming
-    Publish events             $publishEvents
-    Receive events             $receiveEvents
-    Get Subscription stats     $getSubscriptionStats
+    Start streaming bad events $startStreamBadEvents
+    Publish good events        $publishGoodEvents
+    Receive bad event          $receiveBadEvent
     Close connection           $closeConnection
     Delete subscription        $deleteSubscription
     Delete event type          $deleteEventType
@@ -59,6 +73,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     EventTypes(nakadiUri, None)
 
   def createEventType = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
     val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
 
     future must be_==(()).await(retries = 3, timeout = 10 seconds)
@@ -67,10 +83,9 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
   val currentSubscriptionId: Promise[SubscriptionId] = Promise()
   val currentStreamId: Promise[StreamId]             = Promise()
   var events: Option[List[SomeEvent]]                = None
-  val eventCounter                                   = new AtomicInteger(0)
-  val subscriptionClosed: AtomicBoolean              = new AtomicBoolean(false)
-  val modifySourceFunctionActivated: AtomicBoolean   = new AtomicBoolean(false)
-  val streamComplete: Promise[Unit]                  = Promise()
+  val receivedBadEvent: Promise[Unit]                = Promise()
+  var subscriptionClosed: Boolean                    = false
+  val streamComplete: Promise[Boolean]               = Promise()
 
   def createSubscription = (name: String) => {
     implicit val flowId: FlowId = Utils.randomFlowId()
@@ -91,12 +106,59 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     }
 
     future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
-      .await(0, timeout = 5 seconds)
+      .await(0, timeout = 3 seconds)
   }
 
-  def publishEvents = (name: String) => {
+  implicit val mySupervisionDecider =
+    Subscriptions.EventStreamSupervisionDecider { eventStreamContext: EventStreamContext =>
+      {
+        case parsingException: Subscriptions.EventJsonParsingException =>
+          eventStreamContext.subscriptionsClient.commitCursors(
+            eventStreamContext.subscriptionId,
+            SubscriptionCursor(List(parsingException.subscriptionEventInfo.cursor)),
+            eventStreamContext.streamId)
+
+          receivedBadEvent.complete(Success(()))
+          Supervision.Resume
+        case _ => Supervision.Stop
+      }
+    }
+
+  def startStreamBadEvents = (name: String) => {
     implicit val flowId: FlowId = Utils.randomFlowId()
     flowId.pp(name)
+    def stream =
+      for {
+        subscriptionId <- currentSubscriptionId.future
+        stream <- subscriptionsClient.eventsStreamedManaged[SomeBadEvent](
+                   subscriptionId,
+                   EventCallback.successAlways { eventCallbackData =>
+                     eventCallbackData.subscriptionEvent.events
+                       .getOrElse(List.empty)
+                       .foreach { _ =>
+                         ()
+                       }
+                   },
+                   ConnectionClosedCallback { connectionClosedData =>
+                     // Connection will be already closed
+                     subscriptionClosed = true
+                   }
+                 )
+      } yield stream
+
+    stream.onComplete {
+      case scala.util.Success(streamId) =>
+        streamId.pp
+        currentStreamId.complete(Success(streamId))
+      case _ =>
+    }
+
+    currentStreamId.future.map(_ => ()) must be_==(())
+      .await(0, timeout = 4 minutes)
+
+  }
+
+  def publishGoodEvents = (name: String) => {
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
 
@@ -114,65 +176,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     future must be_==(()).await(retries = 3, timeout = 10 seconds)
   }
 
-  def startStreaming = (name: String) => {
-    implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
-    def stream =
-      for {
-        subscriptionId <- currentSubscriptionId.future
-        stream <- subscriptionsClient.eventsStreamedManaged[SomeEvent](
-                   subscriptionId,
-                   EventCallback.successAlways { eventCallbackData =>
-                     eventCallbackData.subscriptionEvent.events
-                       .getOrElse(List.empty)
-                       .foreach {
-                         case e: Event.Business[SomeEvent] =>
-                           if (events.get.contains(e.data)) {
-                             eventCounter.addAndGet(1)
-                           }
-                           if (eventCounter.get() == 2)
-                             streamComplete.complete(Success(()))
-                         case _ =>
-                       }
-                   },
-                   ConnectionClosedCallback { connectionClosedData =>
-                     if (connectionClosedData.cancelledByClient)
-                       subscriptionClosed.set(true)
-                   },
-                   Subscriptions.StreamConfig(),
-                   Some { source =>
-                     modifySourceFunctionActivated.set(true)
-                     source
-                   }
-                 )
-      } yield stream
-
-    stream.onComplete {
-      case scala.util.Success(streamId) =>
-        streamId.pp
-        currentStreamId.complete(Success(streamId))
-      case _ =>
-    }
-
-    currentStreamId.future.map(_ => ()) must be_==(())
-      .await(0, timeout = 4 minutes)
-
-  }
-
-  def receiveEvents = (name: String) => {
-    streamComplete.future must be_==(()).await(0, timeout = 5 minutes)
-  }
-
-  def getSubscriptionStats = (name: String) => {
-    implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
-
-    val statsPresent = for {
-      subscriptionId <- currentSubscriptionId.future
-      stats          <- subscriptionsClient.stats(subscriptionId)
-    } yield stats.isDefined
-
-    statsPresent must be_==(true).await(retries = 3, timeout = 10 seconds)
+  def receiveBadEvent = (name: String) => {
+    receivedBadEvent.future must be_==(()).await(0, timeout = 5 minutes)
   }
 
   def closeConnection = (name: String) => {
@@ -184,15 +189,14 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     } yield subscriptionsClient.closeHttpConnection(subscriptionId, streamId)
 
     val waitForCloseFuture =
-      akka.pattern.after(3 seconds, system.scheduler)(Future.successful(subscriptionClosed.get()))
+      akka.pattern.after(6 seconds, system.scheduler)(Future.successful(subscriptionClosed))
 
     val future = for {
-      closed                <- closedFuture
-      waitForClose          <- waitForCloseFuture
-      modifySourceActivated = modifySourceFunctionActivated.get()
-    } yield (closed, waitForClose, modifySourceActivated)
+      closed       <- closedFuture
+      waitForClose <- waitForCloseFuture
+    } yield (closed | waitForClose) // either connection has been closed earlier or from our client side
 
-    future must be_==((true, true, true)).await(0, timeout = 1 minute)
+    future must be_==(true).await(0, timeout = 1 minute)
   }
 
   def deleteSubscription = (name: String) => {
@@ -200,8 +204,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
     flowId.pp(name)
     val future = for {
       subscriptionId <- currentSubscriptionId.future
-      delete         <- subscriptionsClient.delete(subscriptionId)
-    } yield delete
+      _              <- subscriptionsClient.delete(subscriptionId)
+    } yield ()
 
     future must be_==(()).await(retries = 3, timeout = 10 seconds)
   }

--- a/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -10,13 +12,12 @@ import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
-import org.zalando.kanadi.Config
 import org.zalando.kanadi.api.Subscriptions.defaultEventStreamSupervisionDecider
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
-import scala.concurrent.duration._
 import scala.concurrent.Promise
+import scala.concurrent.duration._
 import scala.util.Success
 
 class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {

--- a/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -11,7 +13,6 @@ import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
-import org.zalando.kanadi.Config
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models.{EventTypeName, SubscriptionId}
 

--- a/src/test/scala/org/zalando/kanadi/OAuthFailedSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/OAuthFailedSpec.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
@@ -9,12 +11,11 @@ import org.specs2.concurrent.ExecutionEnv
 import org.specs2.execute.Skipped
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
-import org.zalando.kanadi.Config
 import org.zalando.kanadi.api.{Events, Subscriptions}
 import org.zalando.kanadi.models._
 
-import concurrent.duration._
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
 

--- a/src/test/scala/org/zalando/kanadi/SomeEvent.scala
+++ b/src/test/scala/org/zalando/kanadi/SomeEvent.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import java.util.UUID
 
 import io.circe.{Decoder, Encoder}

--- a/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import java.util.UUID
 
 import akka.actor.ActorSystem
@@ -9,7 +11,6 @@ import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.specification.core.SpecStructure
 import org.specs2.specification.{AfterAll, BeforeAll}
-import org.zalando.kanadi.Config
 import org.zalando.kanadi.api.{Category, EventType, EventTypes, Events, Subscription, Subscriptions}
 import org.zalando.kanadi.models.{EventTypeName, SubscriptionId}
 

--- a/src/test/scala/org/zalando/kanadi/TokenProvider.scala
+++ b/src/test/scala/org/zalando/kanadi/TokenProvider.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import org.mdedetrich.webmodels.{OAuth2Token, OAuth2TokenProvider}
 
 import scala.concurrent.Future

--- a/src/test/scala/org/zalando/kanadi/Utils.scala
+++ b/src/test/scala/org/zalando/kanadi/Utils.scala
@@ -1,3 +1,5 @@
+package org.zalando.kanadi
+
 import org.mdedetrich.webmodels.FlowId
 
 object Utils {

--- a/src/test/scala/org/zalando/kanadi/api/JsonSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/JsonSpec.scala
@@ -1,3 +1,6 @@
+package org.zalando.kanadi
+package api
+
 import java.util.UUID
 
 import cats.syntax.either._
@@ -7,10 +10,7 @@ import org.specs2.specification.core.SpecStructure
 import io.circe._
 import io.circe.parser._
 import io.circe.syntax._
-import io.circe.java8.time._
-import org.zalando.kanadi.api.Event
-import org.zalando.kanadi.api.DataOperation
-import org.zalando.kanadi.api.Metadata
+import CrossVersionImports._
 import org.zalando.kanadi.models.{EventId, SpanCtx}
 import java.time.OffsetDateTime
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.4.3-SNAPSHOT"
+version := "0.5.0"


### PR DESCRIPTION
Support for Scala 2.13.x. Note that we also set the version of Circe to be 0.12.3 for all versions of Scala apart from 2.11.x (where this version of Circe doesn't exist).

Note that the tests had to be moved to `org.zalando.kanadi.api` because one of the tests needed `CrossScalaImplicits` which is only visible in `org.zalando.kanadi.api`