### PR TITLE
Retry sending events on 5xx

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -357,7 +357,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[EventType]]
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result
@@ -406,7 +406,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
           response.discardEntityBytes()
           Future.successful(())
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result
@@ -445,7 +445,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
             .to[EventType]
             .map(Some.apply)
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result
@@ -482,7 +482,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
           response.discardEntityBytes()
           Future.successful(())
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result
@@ -521,7 +521,7 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
           response.discardEntityBytes()
           Future.successful(())
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result

--- a/src/main/scala/org/zalando/kanadi/api/Registry.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Registry.scala
@@ -52,7 +52,7 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[String]]
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result
@@ -93,7 +93,7 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[PartitionStrategy]]
         } else {
-          processNotSuccessful(response)
+          processNotSuccessful(request, response)
         }
       }
     } yield result

--- a/src/main/scala/org/zalando/kanadi/api/package.scala
+++ b/src/main/scala/org/zalando/kanadi/api/package.scala
@@ -66,8 +66,9 @@ package object api {
       MDC.remove("flow_id")
   }
 
-  def processNotSuccessful(response: HttpResponse)(implicit materializer: Materializer,
-                                                   executionContext: ExecutionContext): Future[Nothing] =
+  def processNotSuccessful(request: HttpRequest, response: HttpResponse)(
+      implicit materializer: Materializer,
+      executionContext: ExecutionContext): Future[Nothing] =
     for {
       json <- Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
                .to[Json]
@@ -80,7 +81,7 @@ package object api {
             case Right(basicServerError) =>
               throw OtherError(basicServerError)
           }
-        case Right(problem) => throw new GeneralError(problem)
+        case Right(problem) => throw new GeneralError(problem, request, response)
       }
     }
 }

--- a/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
@@ -3,7 +3,8 @@ package org.zalando.kanadi.models
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import org.mdedetrich.webmodels.Problem
 
-class GeneralError(val problem: Problem) extends Exception {
+class GeneralError(val problem: Problem, override val httpRequest: HttpRequest, override val httpResponse: HttpResponse)
+    extends HttpServiceError(httpRequest, httpResponse) {
   override def getMessage: String = s"Error from server, response is $problem"
 }
 
@@ -11,7 +12,10 @@ final case class OtherError(error: BasicServerError) extends Exception {
   override def getMessage: String = s"Error from server, response is $error"
 }
 
-class ExpectedHeader(headerName: String, request: HttpRequest, response: HttpResponse) extends Exception {
+class ExpectedHeader(val headerName: String,
+                     override val httpRequest: HttpRequest,
+                     override val httpResponse: HttpResponse)
+    extends HttpServiceError(httpRequest, httpResponse) {
   override def getMessage: String =
-    s"Expected header with name: $headerName, request is $request, response is $response"
+    s"Expected header with name: $headerName, request is $httpRequest, response is $httpResponse"
 }

--- a/src/main/scala/org/zalando/kanadi/models/HttpServiceError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/HttpServiceError.scala
@@ -1,0 +1,5 @@
+package org.zalando.kanadi.models
+
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+
+class HttpServiceError(val httpRequest: HttpRequest, val httpResponse: HttpResponse) extends Exception


### PR DESCRIPTION
This PR is about retrying the sending of an event incase the server sends a `5xx` response (we have had issues in production where server has responded with 500).

This is done by making a new error class called `HttpServiceError` which `GeneralError` extends. We then have to propagate the `HttpRequest` and `HttpResponse` so when we catch it we can get the original status response from the request.