### PR TITLE
Fix webmodels mandatory type field regression

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -30,11 +30,11 @@ sealed abstract class Audience(val id: String) extends EnumEntry with Product wi
 
 object Audience extends Enum[Audience] {
   val values = findValues
-  case object BusinessUnitInternal extends Audience("business-unit-internal")
-  case object CompanyInternal      extends Audience("company-internal")
-  case object ComponentInternal    extends Audience("component-internal")
-  case object ExternalPartner      extends Audience("external-partner")
-  case object ExternalPublic       extends Audience("external-public")
+  final case object BusinessUnitInternal extends Audience("business-unit-internal")
+  final case object CompanyInternal      extends Audience("company-internal")
+  final case object ComponentInternal    extends Audience("component-internal")
+  final case object ExternalPartner      extends Audience("external-partner")
+  final case object ExternalPublic       extends Audience("external-public")
 
   implicit val audienceEncoder: Encoder[Audience] =
     enumeratum.Circe.encoder(Audience)
@@ -49,9 +49,9 @@ sealed abstract class Category(val id: String) extends EnumEntry with Product wi
 
 object Category extends Enum[Category] {
   val values = findValues
-  case object Business  extends Category("business")
-  case object Data      extends Category("data")
-  case object Undefined extends Category("undefined")
+  final case object Business  extends Category("business")
+  final case object Data      extends Category("data")
+  final case object Undefined extends Category("undefined")
 
   implicit val categoryEncoder: Encoder[Category] =
     enumeratum.Circe.encoder(Category)
@@ -66,7 +66,7 @@ sealed abstract class EnrichmentStrategy(val id: String) extends EnumEntry with 
 
 object EnrichmentStrategy extends Enum[EnrichmentStrategy] {
   val values = findValues
-  case object MetadataEnrichment extends EnrichmentStrategy("metadata_enrichment")
+  final case object MetadataEnrichment extends EnrichmentStrategy("metadata_enrichment")
 
   implicit val enrichmentStrategyEncoder: Encoder[EnrichmentStrategy] =
     enumeratum.Circe.encoder(EnrichmentStrategy)
@@ -80,9 +80,9 @@ sealed abstract class PartitionStrategy(val id: String) extends EnumEntry with P
 
 object PartitionStrategy extends Enum[PartitionStrategy] {
   val values = findValues
-  case object Random      extends PartitionStrategy("random")
-  case object UserDefined extends PartitionStrategy("user_defined")
-  case object Hash        extends PartitionStrategy("hash")
+  final case object Random      extends PartitionStrategy("random")
+  final case object UserDefined extends PartitionStrategy("user_defined")
+  final case object Hash        extends PartitionStrategy("hash")
 
   implicit val partitionStrategyEncoder: Encoder[PartitionStrategy] =
     enumeratum.Circe.encoder(PartitionStrategy)
@@ -96,8 +96,8 @@ sealed abstract class CleanupPolicy(val id: String) extends EnumEntry with Produ
 
 object CleanupPolicy extends Enum[CleanupPolicy] {
   val values = findValues
-  case object Compact extends CleanupPolicy("compact")
-  case object Delete  extends CleanupPolicy("delete")
+  final case object Compact extends CleanupPolicy("compact")
+  final case object Delete  extends CleanupPolicy("delete")
 
   implicit val cleanupPolicyEncoder: Encoder[CleanupPolicy] =
     enumeratum.Circe.encoder(CleanupPolicy)
@@ -111,9 +111,9 @@ sealed abstract class CompatibilityMode(val id: String) extends EnumEntry with P
 
 object CompatibilityMode extends Enum[CompatibilityMode] {
   val values = findValues
-  case object Compatible extends CompatibilityMode("compatible")
-  case object Forward    extends CompatibilityMode("forward")
-  case object None       extends CompatibilityMode("none")
+  final case object Compatible extends CompatibilityMode("compatible")
+  final case object Forward    extends CompatibilityMode("forward")
+  final case object None       extends CompatibilityMode("none")
 
   implicit val compatibilityModeEncoder: Encoder[CompatibilityMode] =
     enumeratum.Circe.encoder(CompatibilityMode)
@@ -128,8 +128,7 @@ final case class EventTypeSchema(version: Option[String],
                                  schema: Json)
 
 object EventTypeSchema {
-
-  val anyJsonObject = EventTypeSchema(
+  val anyJsonObject: EventTypeSchema = EventTypeSchema(
     None,
     None,
     EventTypeSchema.Type.JsonSchema,
@@ -143,7 +142,7 @@ object EventTypeSchema {
   object Type extends Enum[Type] {
     val values = findValues
 
-    case object JsonSchema extends Type("json_schema")
+    final case object JsonSchema extends Type("json_schema")
 
     implicit val eventTypeSchemaTypeEncoder: Encoder[Type] =
       enumeratum.Circe.encoder(Type)
@@ -232,7 +231,6 @@ object EventTypeOptions {
 }
 
 /**
-  *
   * @param name Name of this [[EventType]]. The name is constrained by a regular expression. Note: the name can encode the owner/responsible for this [[EventType]] and ideally should follow a common pattern that makes it easy to read and understand, but this level of structure is not enforced. For example a team name and data type can be used such as 'acme-team.price-change'.
   * @param owningApplication Indicator of the (Stups) Application owning this [[EventType]].
   * @param category Defines the category of this [[EventType]]. The value set will influence, if not set otherwise, the default set of validations, [[enrichmentStrategies]], and the effective schema for validation in the following way: - [[Category.Undefined]]: No predefined changes apply. The effective schema for the validation is exactly the same as the [[EventTypeSchema]]. - `data`: Events of this category will be [[org.zalando.kanadi.api.Event.DataChange]]. The effective schema during the validation contains [[org.zalando.kanadi.api.Metadata]], and adds fields [[org.zalando.kanadi.api.Event.DataChange.data]] and [[org.zalando.kanadi.api.Event.DataChange.dataType]]. The passed [[EventTypeSchema]] defines the schema of [[org.zalando.kanadi.api.Event.DataChange.data]]. - [[Category.Business]]: Events of this category will be [[org.zalando.kanadi.api.Event.Business]]. The effective schema for validation contains [[org.zalando.kanadi.api.Metadata]] and any additionally defined properties passed in the [[EventTypeSchema]] directly on top level of the [[org.zalando.kanadi.api.Event]]. If name conflicts arise, creation of this [[EventType]] will be rejected.
@@ -356,9 +354,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
         if (response.status.isSuccess()) {
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[EventType]]
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }
@@ -405,9 +402,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
         if (response.status.isSuccess()) {
           response.discardEntityBytes()
           Future.successful(())
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }
@@ -444,9 +440,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[EventType]
             .map(Some.apply)
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }
@@ -481,9 +476,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
         if (response.status.isSuccess()) {
           response.discardEntityBytes()
           Future.successful(())
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }
@@ -520,9 +514,8 @@ case class EventTypes(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvi
         if (response.status.isSuccess()) {
           response.discardEntityBytes()
           Future.successful(())
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }

--- a/src/main/scala/org/zalando/kanadi/api/Registry.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Registry.scala
@@ -51,9 +51,8 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
         if (response.status.isSuccess()) {
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[String]]
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }
@@ -92,9 +91,8 @@ case class Registry(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenProvide
         if (response.status.isSuccess()) {
           Unmarshal(response.entity.httpEntity.withContentType(ContentTypes.`application/json`))
             .to[List[PartitionStrategy]]
-        } else {
+        } else
           processNotSuccessful(request, response)
-        }
       }
     } yield result
   }

--- a/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
@@ -1,0 +1,153 @@
+package org.zalando.kanadi
+
+import java.util.UUID
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.stream.ActorMaterializer
+import com.typesafe.config.ConfigFactory
+import org.mdedetrich.webmodels.FlowId
+import org.specs2.Specification
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.matcher.FutureMatchers
+import org.specs2.specification.core.SpecStructure
+import org.zalando.kanadi.api.Subscriptions.{
+  ConnectionClosedCallback,
+  EventCallback,
+  defaultEventStreamSupervisionDecider
+}
+import org.zalando.kanadi.api._
+import org.zalando.kanadi.models._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Future, Promise}
+import scala.util.Success
+
+class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
+  override def is: SpecStructure = sequential ^ s2"""
+    Create Event Type                            $createEventType
+    Create Subscription events                   $createSubscription
+    Start streaming and recover from noEmptySlot $startStreaming
+    """
+
+  val config = ConfigFactory.load()
+
+  implicit val system       = ActorSystem()
+  implicit val http         = Http()
+  implicit val materializer = ActorMaterializer()
+
+  val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
+
+  eventTypeName.pp
+
+  val OwningApplication = "KANADI"
+
+  val consumerGroup = UUID.randomUUID().toString
+
+  s"Consumer Group: $consumerGroup".pp
+
+  val subscriptionsClient =
+    Subscriptions(nakadiUri, None)
+  val eventsClient = Events(nakadiUri, None)
+  val eventsTypesClient =
+    EventTypes(nakadiUri, None)
+
+  def createEventType = (name: String) => {
+    val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
+
+    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+  }
+
+  val currentSubscriptionId: Promise[SubscriptionId] = Promise()
+  val currentStreamId: Promise[StreamId]             = Promise()
+  var events: Option[List[SomeEvent]]                = None
+  val eventCounter                                   = new AtomicInteger(0)
+  val subscriptionClosed: AtomicBoolean              = new AtomicBoolean(false)
+  val modifySourceFunctionActivated: AtomicBoolean   = new AtomicBoolean(false)
+  val streamComplete: Promise[Unit]                  = Promise()
+
+  def createSubscription = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+    val future = subscriptionsClient.createIfDoesntExist(
+      Subscription(
+        None,
+        OwningApplication,
+        Some(List(eventTypeName)),
+        Some(consumerGroup)
+      ))
+
+    future.onComplete {
+      case scala.util.Success(subscription) =>
+        subscription.id.pp
+        currentSubscriptionId.complete(Success(subscription.id.get))
+      case _ =>
+    }
+
+    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
+      .await(0, timeout = 5 seconds)
+  }
+
+  def publishEvents = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+    val uUIDOne = java.util.UUID.randomUUID()
+    val uUIDTwo = java.util.UUID.randomUUID()
+
+    events = Some(
+      List(
+        SomeEvent("Robert", "Terwilliger", uUIDOne),
+        SomeEvent("Die", "Bart, Die", uUIDTwo)
+      ))
+
+    val future = eventsClient.publish[SomeEvent](
+      eventTypeName,
+      events.get.map(x => Event.Business(x))
+    )
+
+    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+  }
+
+  def startStreaming = (name: String) => {
+    implicit val flowId: FlowId = Utils.randomFlowId()
+    flowId.pp(name)
+
+    // Start stream One immediately
+    val eventualStreamOne = for {
+      subscriptionId <- currentSubscriptionId.future
+      stream <- subscriptionsClient.eventsStreamedManaged[SomeEvent](
+                 subscriptionId,
+                 EventCallback.successAlways { eventCallbackData =>
+                   eventCallbackData.subscriptionEvent.events
+                     .getOrElse(List.empty)
+                 }
+               )
+    } yield stream
+
+    def eventualStreamTwo =
+      for {
+        subscriptionId <- currentSubscriptionId.future
+        stream <- subscriptionsClient.eventsStreamedManaged[SomeEvent](
+                   subscriptionId,
+                   EventCallback.successAlways { eventCallbackData =>
+                     eventCallbackData.subscriptionEvent.events
+                       .getOrElse(List.empty)
+                   }
+                 )
+      } yield stream
+
+    val future = for {
+      subscriptionId <- currentSubscriptionId.future
+      streamId       <- eventualStreamOne
+      _              <- akka.pattern.after(100 millis, system.scheduler)(Future.successful(()))
+      streamTwo      = eventualStreamTwo
+      _              <- akka.pattern.after(100 millis, system.scheduler)(Future.successful(()))
+      _              = subscriptionsClient.closeHttpConnection(subscriptionId, streamId)
+      _              <- streamTwo
+    } yield ()
+
+    future must be_==(()).await(0, timeout = 4 minutes)
+
+  }
+}

--- a/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
@@ -57,9 +57,9 @@ class EventPublishRetrySpec(implicit ec: ExecutionEnv) extends Specification wit
 
   object State {
 
-    case object Initial extends State
+    final case object Initial extends State
 
-    case class RetryFailed(failedEvents: List[Event[EventData]]) extends State
+    final case class RetryFailed(failedEvents: List[Event[EventData]]) extends State
 
   }
 


### PR DESCRIPTION
This PR does 2 things

1. Does some code cleanups (i.e. making some `case objects` `final` as well as minor adjustments to logging
2. Fixes a regression introduced by https://github.com/zalando-nakadi/kanadi/pull/132 . That PR updates webmodels which now has `type` as a mandatory field. Even though the Nakadi API has `type` as a mandatory field for `Problem`, this doesn't reflect in all errors that Nakadi returns which means that errors such as `NoEmptySlotsOrCursorReset` didn't serialize properly because we were expecting a `Problem` with a `type` field. A test was also added to verify this. An issue at https://github.com/zalando-nakadi/kanadi/issues/134 has been made to track this.