### PR TITLE
Marshal the response body into HttpServiceError

### DIFF
--- a/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/GeneralError.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import org.mdedetrich.webmodels.Problem
 
 class GeneralError(val problem: Problem, override val httpRequest: HttpRequest, override val httpResponse: HttpResponse)
-    extends HttpServiceError(httpRequest, httpResponse) {
+    extends HttpServiceError(httpRequest, httpResponse, Right(problem)) {
   override def getMessage: String = s"Error from server, response is $problem"
 }
 
@@ -15,7 +15,7 @@ final case class OtherError(error: BasicServerError) extends Exception {
 class ExpectedHeader(val headerName: String,
                      override val httpRequest: HttpRequest,
                      override val httpResponse: HttpResponse)
-    extends HttpServiceError(httpRequest, httpResponse) {
+    extends HttpServiceError(httpRequest, httpResponse, Left("")) {
   override def getMessage: String =
     s"Expected header with name: $headerName, request is $httpRequest, response is $httpResponse"
 }

--- a/src/main/scala/org/zalando/kanadi/models/HttpServiceError.scala
+++ b/src/main/scala/org/zalando/kanadi/models/HttpServiceError.scala
@@ -1,5 +1,9 @@
 package org.zalando.kanadi.models
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import org.mdedetrich.webmodels.Problem
 
-class HttpServiceError(val httpRequest: HttpRequest, val httpResponse: HttpResponse) extends Exception
+class HttpServiceError(val httpRequest: HttpRequest,
+                       val httpResponse: HttpResponse,
+                       val stringOrProblem: Either[String, Problem])
+    extends Exception


### PR DESCRIPTION
In the https://github.com/zalando-nakadi/kanadi/pull/133 PR we fixed a regression which was introduced due to Nakadi not properly following the `Problem` spec (see https://github.com/zalando-nakadi/kanadi/issues/134).

Unfortunately in that PR we also lose any context of the response because `HttpServiceError` didn't contain the response body and we had to discard the response body due to the streaming nature of akka-streams.

This PR fixes this.