### PR TITLE
Update akka-http version and remove depreciation warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,18 @@
 name := """kanadi"""
 
-val akkaHttpVersion                    = "10.1.11"
-val akkaStreamsJsonVersion             = "0.6.0"
+val akkaHttpVersion                    = "10.2.2"
+val akkaStreamsJsonVersion             = "0.7.0"
 val currentScalaVersion                = "2.12.11"
-val scala213Version                    = "2.13.1"
+val scala213Version                    = "2.13.4"
 val enumeratumCirceVersion             = "1.5.23"
 val circeVersion                       = "0.13.0"
-val akkaVersion                        = "2.6.3"
+val akkaVersion                        = "2.6.10"
 val specs2Version                      = "4.8.0"
-val heikoseebergerAkkaHttpCirceVersion = "1.31.0"
+val heikoseebergerAkkaHttpCirceVersion = "1.35.3"
 
 scalaVersion in ThisBuild := currentScalaVersion
 
-crossScalaVersions in ThisBuild := Seq(currentScalaVersion, "2.13.1")
+crossScalaVersions in ThisBuild := Seq(currentScalaVersion, scala213Version)
 
 organization := "org.zalando"
 
@@ -123,10 +123,7 @@ developers := List(
             "Goutham Vidya Pradhan",
             "goutham.vidya.pradhan@gmail.com",
             url("https://github.com/gouthampradhan")),
-  Developer("javierarrieta",
-            "Javier Arrieta",
-            "javier.arrieta@zalando.ie",
-            url("https://github.com/javierarrieta")),
+  Developer("javierarrieta", "Javier Arrieta", "javier.arrieta@zalando.ie", url("https://github.com/javierarrieta")),
   Developer("pascalh", "Pascal Hof", "pascal.hof@zalando.de", url("https://github.com/pascalh"))
 )
 

--- a/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
+++ b/src/main/scala/org/zalando/kanadi/api/EventTypes.scala
@@ -10,7 +10,6 @@ import akka.http.scaladsl.model.headers.RawHeader
 import akka.http.scaladsl.model.{HttpMethods, HttpRequest, _}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import akka.stream.scaladsl.Sink
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import enumeratum._

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -25,7 +25,6 @@ import org.zalando.kanadi.api.defaults._
 import org.zalando.kanadi.models._
 import org.mdedetrich.akka.stream.support.CirceStreamSupport
 import org.mdedetrich.webmodels.{FlowId, OAuth2TokenProvider, Problem}
-import org.mdedetrich.webmodels.circe._
 import org.zalando.kanadi.models
 
 import scala.collection.JavaConverters._
@@ -252,7 +251,6 @@ object Subscriptions {
         "event_type"
       )(CursorWithoutToken.apply)
   }
-
 
   final case class EventTypeStats(eventType: EventTypeName, partitions: List[EventTypeStats.Partition])
 

--- a/src/main/scala/org/zalando/kanadi/api/package.scala
+++ b/src/main/scala/org/zalando/kanadi/api/package.scala
@@ -10,7 +10,6 @@ import com.typesafe.scalalogging.CanLog
 import io.circe._
 import org.mdedetrich.webmodels.RequestHeaders.`X-Flow-ID`
 import org.mdedetrich.webmodels.{FlowId, OAuth2Token, Problem}
-import org.mdedetrich.webmodels.circe._
 import org.slf4j.MDC
 import org.zalando.kanadi.models._
 
@@ -31,11 +30,11 @@ package object api {
     def decodeCompressed(response: HttpResponse): HttpResponse = {
       val decoder = response.encoding match {
         case HttpEncodings.gzip =>
-          Gzip
+          Coders.Gzip
         case HttpEncodings.deflate =>
-          Deflate
+          Coders.Deflate
         case _ =>
-          NoCoding
+          Coders.NoCoding
       }
 
       decoder.decodeMessage(response)
@@ -91,8 +90,8 @@ package object api {
       None
     else
       for {
-        asJson    <- io.circe.parser.parse(string).right.toOption
-        asProblem <- asJson.as[Problem].right.toOption
+        asJson    <- io.circe.parser.parse(string).toOption
+        asProblem <- asJson.as[Problem].toOption
       } yield asProblem
   }
 

--- a/src/test/scala/org/zalando/kanadi/AuthorizationSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/AuthorizationSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
@@ -28,9 +27,8 @@ class AuthorizationSpec(implicit ec: ExecutionEnv) extends Specification with Fu
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.{ActorMaterializer, Supervision}
+import akka.stream.Supervision
 import com.typesafe.config.ConfigFactory
 import io.circe.{Decoder, Encoder}
 import org.mdedetrich.webmodels.FlowId
@@ -52,9 +52,8 @@ class BadJsonDecodingSpec(implicit ec: ExecutionEnv) extends Specification with 
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink}
 import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
@@ -34,9 +33,8 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/BasicSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BasicSpec.scala
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
@@ -39,9 +38,8 @@ class BasicSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatc
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/CommitCursorBadResponseSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/CommitCursorBadResponseSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import com.typesafe.config.ConfigFactory
 import io.circe.JsonObject
@@ -31,7 +30,6 @@ class CommitCursorBadResponseSpec(implicit ec: ExecutionEnv) extends Specificati
 
   implicit val system       = ActorSystem()
   implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import com.typesafe.config.ConfigFactory
 import io.circe.JsonObject
@@ -29,9 +28,8 @@ class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification w
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
@@ -5,18 +5,13 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
 import org.specs2.matcher.FutureMatchers
 import org.specs2.specification.core.SpecStructure
-import org.zalando.kanadi.api.Subscriptions.{
-  ConnectionClosedCallback,
-  EventCallback,
-  defaultEventStreamSupervisionDecider
-}
+import org.zalando.kanadi.api.Subscriptions.{EventCallback, defaultEventStreamSupervisionDecider}
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
@@ -33,9 +28,8 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 

--- a/src/test/scala/org/zalando/kanadi/OAuthFailedSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/OAuthFailedSpec.scala
@@ -2,9 +2,7 @@ package org.zalando.kanadi
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
-import io.circe.Json
 import org.mdedetrich.webmodels.{FlowId, OAuth2Token, OAuth2TokenProvider}
 import org.specs2.Specification
 import org.specs2.concurrent.ExecutionEnv
@@ -21,9 +19,9 @@ class OAuthFailedSpec(implicit ec: ExecutionEnv) extends Specification with Futu
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
+
   val failingOauth2TokenProvider = Some(
     OAuth2TokenProvider(() => Future.successful(OAuth2Token("Failing token")))
   )

--- a/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.stream.ActorMaterializer
 import com.typesafe.config.ConfigFactory
 import org.mdedetrich.webmodels.FlowId
 import org.specs2.Specification
@@ -25,9 +24,8 @@ class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Co
 
   val config = ConfigFactory.load()
 
-  implicit val system       = ActorSystem()
-  implicit val http         = Http()
-  implicit val materializer = ActorMaterializer()
+  implicit val system = ActorSystem()
+  implicit val http   = Http()
 
   val eventTypeName         = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
   val OwningApplication     = "KANADI"

--- a/src/test/scala/org/zalando/kanadi/api/JsonSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/JsonSpec.scala
@@ -86,7 +86,7 @@ class JsonSpec extends Specification {
     decode[Metadata](spanCtxJson) must beRight(spanCtxEventMetadata)
 
   def encodeSpnCtx =
-    spanCtxEventMetadata.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) mustEqual spanCtxJson
+    spanCtxEventMetadata.asJson.print(Printer.noSpaces.copy(dropNullValues = true)) mustEqual spanCtxJson
 
   def badDecodeSpnCtx =
     decode[Metadata](spanCtxBadJson) must beLeft(


### PR DESCRIPTION
This PR updates to the next major version of akka-http (i.e. 10.2.x). Depreciation warnings due to the akka-http upgrade have been resolved as well as removing unused imports.

We are also now using the new akka-http graceful termination as described in https://doc.akka.io/docs/akka-http/current/server-side/graceful-termination.html