### PR TITLE
Add EarlySemVer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ ThisBuild / scalaVersion := currentScalaVersion
 
 ThisBuild / crossScalaVersions := Seq(currentScalaVersion, scala213Version)
 
+ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
+
 organization := "org.zalando"
 
 Test / fork               := true


### PR DESCRIPTION
This PR adds EarlySemVer to the versioning scheme. This allows SBT to provide proper eviction warnings when Kanadi is included as a library dependency so that users are warned better about possible binary incompatibility issues.