### PR TITLE
Make akka dependencies Provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,9 +81,9 @@ scalacOptions ++= {
 
 libraryDependencies ++= {
   Seq(
-    "com.typesafe.akka"          %% "akka-http"           % akkaHttpVersion,
-    "com.typesafe.akka"          %% "akka-slf4j"          % akkaVersion,
-    "com.typesafe.akka"          %% "akka-stream"         % akkaVersion,
+    "com.typesafe.akka"          %% "akka-http"           % akkaHttpVersion % Provided,
+    "com.typesafe.akka"          %% "akka-slf4j"          % akkaVersion     % Provided,
+    "com.typesafe.akka"          %% "akka-stream"         % akkaVersion     % Provided,
     "org.mdedetrich"             %% "censored-raw-header" % "0.5.0",
     "org.mdedetrich"             %% "webmodels"           % "0.8.1",
     "com.beachape"               %% "enumeratum-circe"    % enumeratumCirceVersion,
@@ -94,7 +94,7 @@ libraryDependencies ++= {
     "com.iheart"                 %% "ficus"               % "1.4.7",
     "com.typesafe.scala-logging" %% "scala-logging"       % "3.9.2",
     "ch.qos.logback"              % "logback-classic"     % "1.1.7",
-    "org.specs2"                 %% "specs2-core"         % specs2Version % Test
+    "org.specs2"                 %% "specs2-core"         % specs2Version   % Test
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, n)) if n == 13 =>
       Seq(


### PR DESCRIPTION
Akka recommends that libraries which use akka/akka-stream should mark the dependencies as `Provided`. This is due to the fact that having mismatched versions of different akka libraries (even if its minor) causes problems, i.e. a project has akka 2.6.5 and akka-streams 2.6.4 this will cause problems.

Marking dependencies as provided forces an application that includes Kanadi to specify a globally consistent version for akka/akka-stream/akka-http etc etc 