### PR TITLE
Add .bsp and .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 .history
 .cache
 .lib/
+
+.idea
+.bsp


### PR DESCRIPTION
Add .bsp and .idea to gitignore

otherwise it might be a problem to release with sbt-release since it will complain that the directory is dirty.

Another option could be:
```
ignoreUntrackedFiles := true
```

but might be better just to add these 2 entries to gitignore.

Signed-off-by: Grigorii Chudnov <g.chudnov@gmail.com>