### PR TITLE
add show_time_lag to subscription stats function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ project/plugins/project/
 .history
 .cache
 .lib/
+
+.bsp/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,3 @@ project/plugins/project/
 .history
 .cache
 .lib/
-
-.bsp/
-.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   nakadi:
-    image: docker.pkg.github.com/adyach/nakadi-docker/nakadi:3.3.8
+    image: adyach/nakadi-docker:3.3.8
     ports:
      - "8080:8080"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   nakadi:
-    image: docker.pkg.github.com/adyach/nakadi-docker/nakadi:latest
+    image: docker.pkg.github.com/adyach/nakadi-docker/nakadi:3.3.8
     ports:
      - "8080:8080"
     depends_on:

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1629,9 +1629,13 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
       flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext
   ): Future[Option[SubscriptionStats]] = {
+    val showTimeLagQuery: Query = if (showTimeLag) {
+      Query("show_time_lag" -> showTimeLag.toString)
+    } else Query.Empty
+
     val uri = baseUri_
       .withPath(baseUri_.path / "subscriptions" / subscriptionId.id.toString / "stats")
-      .withQuery(Query("show_time_lag" -> showTimeLag.toString))
+      .withQuery(showTimeLagQuery)
 
     for {
       headers <- oAuth2TokenProvider match {

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1625,12 +1625,13 @@ case class Subscriptions(baseUri: URI, oAuth2TokenProvider: Option[OAuth2TokenPr
     *   operational troubleshooting and log analysis.
     * @return
     */
-  def stats(subscriptionId: SubscriptionId)(implicit
+  def stats(subscriptionId: SubscriptionId, showTimeLag: Boolean = false)(implicit
       flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext
   ): Future[Option[SubscriptionStats]] = {
     val uri = baseUri_
       .withPath(baseUri_.path / "subscriptions" / subscriptionId.id.toString / "stats")
+      .withQuery(Query("show_time_lag" -> showTimeLag.toString))
 
     for {
       headers <- oAuth2TokenProvider match {

--- a/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
+++ b/src/main/scala/org/zalando/kanadi/api/SubscriptionsInterface.scala
@@ -125,7 +125,7 @@ trait SubscriptionsInterface {
 
   def closeHttpConnection(subscriptionId: SubscriptionId, streamId: StreamId): Boolean
 
-  def stats(subscriptionId: SubscriptionId)(implicit
+  def stats(subscriptionId: SubscriptionId, showTimeLag: Boolean = false)(implicit
       flowId: FlowId = randomFlowId(),
       executionContext: ExecutionContext
   ): Future[Option[SubscriptionStats]]


### PR DESCRIPTION
This PR is to add the flag `show_time_lag` to the subscription stats endpoint to be aligned with the nakadi doc, so the subsequent response will populate the consumer time lag field (if nakadi computation not times-out)

Reference: https://nakadi.io/manual.html#/subscriptions/subscription_id/stats_get