### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,36 +27,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Java (temurin@11)
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 11
-
-      - name: Cache sbt
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
-            ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          cache: sbt
 
       - name: Check that workflows are up to date
-        run: sbt ++${{ matrix.scala }} githubWorkflowCheck
+        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,13 +53,13 @@ jobs:
         run: docker-compose up -d
 
       - name: Build project
-        run: sbt ++${{ matrix.scala }} clean coverage test
+        run: sbt '++ ${{ matrix.scala }}' clean coverage test
 
       - name: Upload coverage data to Coveralls
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
+        run: sbt '++ ${{ matrix.scala }}' coverageReport coverageAggregate coveralls
 
       - name: Shut down Nakadi
         run: docker-compose down

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v1
+        uses: jrouly/scalafmt-native-action@v2
         with:
           version: '3.1.2'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This means that in order to pull the necessary images you need to create a [gith
 with the scope `read:packages`. After this you need to login to docker for github container registry, i.e.
 
 ```shell
-docker login -u <github username> -p <personal access token> docker.pkg.github.com
+docker login -u <github username> -p <personal access token> ghcr.io
 ```
 
 After this `docker-compose` should work as expected

--- a/build.sbt
+++ b/build.sbt
@@ -9,16 +9,21 @@ libraryDependencies ++= {
 
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Use(
-    UseRef.Public("docker", "login-action", "v1"),
+    UseRef.Public("docker", "login-action", "v2"),
     name = Some("Login to GitHub Container Registry"),
     params = Map(
-      "registry" -> "docker.pkg.github.com",
+      "registry" -> "ghcr.io",
       "username" -> "${{ github.actor }}",
       "password" -> "${{ secrets.GITHUB_TOKEN }}"
     )
   ),
   WorkflowStep.Run(List("docker-compose up -d"), name = Some("Launch Nakadi")),
   WorkflowStep.Sbt(List("clean", "coverage", "test"), name = Some("Build project"))
+)
+
+ThisBuild / githubWorkflowJavaVersions := Seq(
+  // See https://github.com/sbt/sbt-github-actions#jdk-settings
+  JavaSpec.temurin("11")
 )
 
 ThisBuild / githubWorkflowBuildPostamble ++= Seq(
@@ -43,7 +48,7 @@ ThisBuild / githubWorkflowUseSbtThinClient := false
 
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
-import ReleaseTransformations._
+import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations.*
 
 releaseCrossBuild := false
 releaseProcess := Seq[ReleaseStep](

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - NAKADI_PLUGINS_AUTHZ_FACTORY=org.crazycoder.nakadiauthzfileplugin.FileAuthorizationServiceFactory
 
   postgres:
-    image: docker.pkg.github.com/adyach/nakadi-docker/postgres:9.5
+    image: ghcr.io/adyach/nakadi-docker/postgres:9.5
     ports:
       - "5432:5432"
     environment:
@@ -25,12 +25,12 @@ services:
       POSTGRES_DB: local_nakadi_db
 
   zookeeper:
-    image: docker.pkg.github.com/adyach/nakadi-docker/zookeeper:3.5.8
+    image: ghcr.io/adyach/nakadi-docker/zookeeper:3.5.8
     ports:
       - "2181:2181"
 
   kafka:
-    image: docker.pkg.github.com/adyach/kafka-docker/kafka-docker:2.7.0
+    image: ghcr.io/adyach/kafka-docker/kafka-docker:2.7.0
     ports:
       - "9092:9092"
     depends_on:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,6 @@ addSbtPlugin("org.xerial.sbt"                    % "sbt-sonatype"       % "3.9.2
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"   % "3.0.2")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"      % "2.0.8")
 addSbtPlugin("org.scoverage"                     % "sbt-coveralls"      % "1.3.9")
-addSbtPlugin("com.codecommit"                    % "sbt-github-actions" % "0.14.2")
+addSbtPlugin("com.github.sbt"                    % "sbt-github-actions" % "0.15.0")
 addSbtPlugin("com.github.sbt"                    % "sbt-release"        % "1.1.0")
 addSbtPlugin("com.timushev.sbt"                  % "sbt-updates"        % "0.6.4")


### PR DESCRIPTION
In this PR:
* Updated `github-actions` plugin to [v0.15.0](https://github.com/sbt/sbt-github-actions/releases/tag/v0.15.0)
* Regenerated CI pipeline
* Migrate from GitHub Docker registry to [Github Container Registry](https://github.com/docker/login-action#github-container-registry) - see [deprecation announcement](https://docs.github.com/en/packages/working-with-a-github-packages-registry/migrating-to-the-container-registry-from-the-docker-registry#about-migration-from-the-docker-registry)