### PR TITLE
Replace Ficus with PureConfig

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object versions {
     val logback                  = "1.4.11"
     val scalaLogging             = "3.9.5"
-    val ficus                    = "1.5.2"
+    val pureConfig               = "0.17.4"
     val pekko                    = "1.0.1"
     val pekkoHttp                = "1.0.0"
     val pekkoStreamJson          = "1.0.0"
@@ -22,7 +22,7 @@ object Dependencies {
   private val circeParser      = "io.circe"                   %% "circe-parser"       % versions.circe
   private val pekkoStreamCirce = "org.mdedetrich"             %% "pekko-stream-circe" % versions.pekkoStreamJson
   private val pekkoHttpCirce   = "org.mdedetrich"             %% "pekko-http-circe"   % versions.pekkoStreamJson
-  private val ficus            = "com.iheart"                 %% "ficus"              % versions.ficus
+  private val pureConfig       = "com.github.pureconfig"      %% "pureconfig"         % versions.pureConfig
   private val scalaLogging     = "com.typesafe.scala-logging" %% "scala-logging"      % versions.scalaLogging
   private val logbackClassic   = "ch.qos.logback"              % "logback-classic"    % versions.logback
   private val specs2           = "org.specs2"                 %% "specs2-core"        % versions.specs2
@@ -45,7 +45,7 @@ object Dependencies {
       circeParser,
       pekkoStreamCirce,
       pekkoHttpCirce,
-      ficus,
+      pureConfig,
       scalaLogging,
       logbackClassic
     ) map (_ % "compile")

--- a/src/main/scala/org/zalando/kanadi/Config.scala
+++ b/src/main/scala/org/zalando/kanadi/Config.scala
@@ -2,18 +2,17 @@ package org.zalando.kanadi
 
 import java.net.URI
 
-import net.ceedubs.ficus.Ficus._
 import org.zalando.kanadi.models.{ExponentialBackoffConfig, HttpConfig}
-import net.ceedubs.ficus.readers.ArbitraryTypeReader._
-import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
+import pureconfig._
+import pureconfig.generic.auto._
 
 trait Config {
   def config: com.typesafe.config.Config
 
-  lazy val nakadiUri: URI = new URI(config.as[String]("kanadi.nakadi.uri"))
+  lazy val nakadiUri: URI = ConfigSource.default.at("kanadi.nakadi.uri").loadOrThrow[URI]
 
-  implicit lazy val kanadiHttpConfig: HttpConfig = config.as[HttpConfig]("kanadi.http-config")
+  implicit lazy val kanadiHttpConfig: HttpConfig = ConfigSource.default.at("kanadi.http-config").loadOrThrow[HttpConfig]
 
   implicit lazy val kanadiExponentialBackoffConfig: ExponentialBackoffConfig =
-    config.as[ExponentialBackoffConfig]("kanadi.exponential-backoff-config")
+    ConfigSource.default.at("kanadi.exponential-backoff-config").loadOrThrow[ExponentialBackoffConfig]
 }

--- a/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
@@ -18,16 +18,15 @@ import org.zalando.kanadi.models.{EventTypeName, ExponentialBackoffConfig, FlowI
 
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
-import net.ceedubs.ficus.readers.namemappers.implicits.hyphenCase
-import net.ceedubs.ficus.readers.ArbitraryTypeReader._
-import net.ceedubs.ficus.Ficus._
 import org.zalando.kanadi.api.Events.Errors
 import org.mdedetrich.pekko.http.support.CirceHttpSupport._
+import pureconfig._
+import pureconfig.generic.auto._
 
 class EventPublishRetrySpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
 
   override lazy implicit val kanadiHttpConfig: HttpConfig =
-    config.as[HttpConfig]("kanadi.http-config").copy(failedPublishEventRetry = true)
+    ConfigSource.default.at("kanadi.http-config").loadOrThrow[HttpConfig].copy(failedPublishEventRetry = true)
 
   override implicit lazy val kanadiExponentialBackoffConfig: ExponentialBackoffConfig =
     ExponentialBackoffConfig(50 millis, 1.5, 5)


### PR DESCRIPTION
This is mainly in preparation for Scala 3. Ficus is not maintained anymore, and even though there is a Scala 3 artifact for it they didn't implement `ArbitraryTypeReader` (see https://github.com/iheartradio/ficus/blob/6d0e09cb4eba1784601b6b114c1126fde31dd7e8/src/main/scala-3/net/ceedubs/ficus/readers/ArbitraryTypeReader.scala#L3-L4) which means that we would have to manually write the typesafe config parsers.