### PR TITLE
Replace specs2 with scalatest

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
     val pekkoStreamJson          = "1.0.0"
     val enumeratumCirce          = "1.7.3"
     val circe                    = "0.14.5"
-    val specs2                   = "4.20.2"
+    val scalaTest                = "3.2.16"
     val scalaParallelCollections = "0.2.0"
   }
 
@@ -25,12 +25,13 @@ object Dependencies {
   private val pureConfig       = "com.github.pureconfig"      %% "pureconfig"         % versions.pureConfig
   private val scalaLogging     = "com.typesafe.scala-logging" %% "scala-logging"      % versions.scalaLogging
   private val logbackClassic   = "ch.qos.logback"              % "logback-classic"    % versions.logback
-  private val specs2           = "org.specs2"                 %% "specs2-core"        % versions.specs2
+  private val scalaTest        = "org.scalatest"              %% "scalatest"          % versions.scalaTest
+  private val pekkoTestKit     = "org.apache.pekko"           %% "pekko-testkit"      % versions.pekko
 
   private val scalaParallelCollections =
     "org.scala-lang.modules" %% "scala-parallel-collections" % versions.scalaParallelCollections
 
-  private val testSeq = Seq(specs2)
+  private val testSeq = Seq(scalaTest, pekkoTestKit)
 
   val test213Seq: Seq[ModuleID] = Seq(scalaParallelCollections)
 

--- a/src/test/scala/org/zalando/kanadi/AsyncFreeTestKitSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/AsyncFreeTestKitSpec.scala
@@ -1,0 +1,13 @@
+package org.zalando.kanadi
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestKitBase
+import org.scalatest.fixture
+import org.scalatest.freespec.FixtureAsyncFreeSpec
+
+class AsyncFreeTestKitSpec(_system: ActorSystem)
+    extends FixtureAsyncFreeSpec
+    with TestKitBase
+    with fixture.AsyncTestDataFixture {
+  implicit val system: ActorSystem = _system
+}

--- a/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BasicSourceSpec.scala
@@ -1,49 +1,35 @@
 package org.zalando.kanadi
 
 import java.util.UUID
-
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.stream.scaladsl.{Keep, Sink}
 import com.typesafe.config.ConfigFactory
-import org.specs2.Specification
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.FutureMatchers
-import org.specs2.specification.core.SpecStructure
+import org.scalatest.TestData
+import org.scalatest.matchers.must.Matchers
 import org.zalando.kanadi.api.Subscriptions.defaultEventStreamSupervisionDecider
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
 import scala.concurrent.Promise
-import scala.concurrent.duration._
 import scala.util.Success
 
-class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
-  override def is: SpecStructure = sequential ^ s2"""
-    Create Event Type          $createEventType
-    Create Subscription events $createSubscription
-    Start streaming            $startStreaming
-    Publish events             $publishEvents
-    Receive events from source $receiveEvents
-    Close connection           $closeConnection
-    Delete subscription        $deleteSubscription
-    Delete event type          $deleteEventType
-    """
+class BasicSourceSpec
+    extends AsyncFreeTestKitSpec(ActorSystem("BasicSourceSpec"))
+    with PekkoTestKitBase
+    with Matchers
+    with Config {
 
   val config = ConfigFactory.load()
 
-  implicit val system = ActorSystem()
-  implicit val http   = Http()
-
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 
-  eventTypeName.pp
+  pp(eventTypeName)
 
   val OwningApplication = "KANADI"
 
   val consumerGroup = UUID.randomUUID().toString
 
-  s"Consumer Group: $consumerGroup".pp
+  pp(s"Consumer Group: $consumerGroup")
 
   val subscriptionsClient =
     Subscriptions(nakadiUri, None)
@@ -51,21 +37,20 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
   val eventsTypesClient =
     EventTypes(nakadiUri, None)
 
-  def createEventType = (name: String) => {
-    val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
-
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
-  }
-
   val currentSubscriptionId: Promise[SubscriptionId] = Promise()
   val currentStreamId: Promise[StreamId]             = Promise()
   var events: Option[List[SomeEvent]]                = None
   var eventCounter                                   = 0
   val streamComplete: Promise[Unit]                  = Promise()
 
-  def createSubscription = (name: String) => {
+  "Create Event Type" in { () =>
+    val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
+    future.map(_ => succeed)
+  }
+
+  "Create Subscription events" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
         None,
@@ -76,18 +61,18 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
 
     future.onComplete {
       case scala.util.Success(subscription) =>
-        subscription.id.pp
+        pp(subscription.id)
         currentSubscriptionId.complete(Success(subscription.id.get))
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
-      .await(0, timeout = 5 seconds)
+    future.map(result =>
+      (result.owningApplication, result.eventTypes) mustEqual ((OwningApplication, Some(List(eventTypeName)))))
   }
 
-  def startStreaming = (name: String) => {
+  "Start streaming" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     def stream =
       for {
         subscriptionId <- currentSubscriptionId.future
@@ -111,19 +96,17 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
 
     stream.onComplete {
       case scala.util.Success(streamId) =>
-        streamId.pp
+        pp(streamId)
         currentStreamId.complete(Success(streamId))
       case _ =>
     }
 
-    currentStreamId.future.map(_ => ()) must be_==(())
-      .await(0, timeout = 4 minutes)
-
+    currentStreamId.future.map(_ => succeed)
   }
 
-  def publishEvents = (name: String) => {
+  "Publish events" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val uUIDOne = java.util.UUID.randomUUID()
     val uUIDTwo = java.util.UUID.randomUUID()
 
@@ -137,15 +120,16 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
       eventTypeName,
       events.get.map(x => Event.Business(x))
     )
-
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+    future.map(_ => succeed)
   }
 
-  def receiveEvents = (name: String) => streamComplete.future must be_==(()).await(0, timeout = 5 minutes)
+  "Receive events from source" in { () =>
+    streamComplete.future.map(_ => succeed)
+  }
 
-  def closeConnection = (name: String) => {
+  "Close connection" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val closedFuture = for {
       subscriptionId <- currentSubscriptionId.future
       streamId       <- currentStreamId.future
@@ -153,26 +137,26 @@ class BasicSourceSpec(implicit ec: ExecutionEnv) extends Specification with Futu
 
     val future = closedFuture
 
-    future must be_==(true).await(0, timeout = 1 minute)
+    future.map(_ => succeed)
   }
 
-  def deleteSubscription = (name: String) => {
+  "Delete subscription" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val future = for {
       subscriptionId <- currentSubscriptionId.future
       delete         <- subscriptionsClient.delete(subscriptionId)
     } yield delete
 
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+    future.map(_ => succeed)
   }
 
-  def deleteEventType = (name: String) => {
+  "Delete event type" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val future = eventsTypesClient.delete(eventTypeName)
 
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+    future.map(_ => succeed)
   }
 
 }

--- a/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/CommitCursorOmittedSpec.scala
@@ -2,42 +2,34 @@ package org.zalando.kanadi
 
 import java.util.UUID
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.stream.scaladsl.Sink
 import com.typesafe.config.ConfigFactory
 import io.circe.JsonObject
-import org.specs2.Specification
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.FutureMatchers
-import org.specs2.specification.core.SpecStructure
+import org.scalatest.TestData
+import org.scalatest.matchers.must.Matchers
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models.{EventTypeName, FlowId, SubscriptionId}
 
 import scala.concurrent.Promise
-import scala.concurrent.duration._
 import scala.util._
 
-class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
-  override def is: SpecStructure = sequential ^ s2"""
-    Create Event Type          $createEventType
-    Create Subscription events $createSubscription
-    Stream subscription        $streamSubscriptionId
-  """
+class CommitCursorOmittedSpec
+    extends AsyncFreeTestKitSpec(ActorSystem("CommitCursorOmittedSpec"))
+    with PekkoTestKitBase
+    with Matchers
+    with Config {
 
   val config = ConfigFactory.load()
 
-  implicit val system = ActorSystem()
-  implicit val http   = Http()
-
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 
-  eventTypeName.pp
+  pp(eventTypeName)
 
   val OwningApplication = "KANADI"
 
   val consumerGroup = UUID.randomUUID().toString
 
-  s"Consumer Group: $consumerGroup".pp
+  pp(s"Consumer Group: $consumerGroup")
 
   val subscriptionsClient =
     Subscriptions(nakadiUri, None)
@@ -48,15 +40,15 @@ class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification w
   val currentSubscriptionId: Promise[SubscriptionId]                             = Promise()
   val successfullyParsedBadCommitResponse: Promise[Option[CommitCursorResponse]] = Promise()
 
-  def createEventType = (name: String) => {
+  "Create Event Type" in { () =>
     val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
 
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+    future.map(_ => succeed)
   }
 
-  def createSubscription = (name: String) => {
+  "Create Subscription events" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
         None,
@@ -67,20 +59,20 @@ class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification w
 
     future.onComplete {
       case Success(subscription) =>
-        subscription.id.pp
+        pp(subscription.id)
         currentSubscriptionId.complete(Success(subscription.id.get))
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
-      .await(0, timeout = 5 seconds)
+    future.map(result =>
+      (result.owningApplication, result.eventTypes) mustEqual ((OwningApplication, Some(List(eventTypeName)))))
   }
 
-  def streamSubscriptionId = (name: String) => {
+  "Stream subscription" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
 
-    val future = for {
+    for {
       subscriptionId <- currentSubscriptionId.future
       _ = subscriptionsClient.eventsStreamedSource[JsonObject](subscriptionId).map { nakadiSource =>
             nakadiSource.source
@@ -101,8 +93,6 @@ class CommitCursorOmittedSpec(implicit ec: ExecutionEnv) extends Specification w
               .runWith(Sink.foreach(_ => ()))
           }
       result <- successfullyParsedBadCommitResponse.future
-    } yield result
-
-    future must beNone.await(0, timeout = 2 minutes)
+    } yield result mustBe empty
   }
 }

--- a/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
@@ -2,43 +2,36 @@ package org.zalando.kanadi
 
 import java.util.UUID
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
-
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
 import com.typesafe.config.ConfigFactory
-import org.specs2.Specification
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.matcher.FutureMatchers
-import org.specs2.specification.core.SpecStructure
+import org.scalatest.TestData
+import org.scalatest.matchers.must.Matchers
 import org.zalando.kanadi.api.Subscriptions.{EventCallback, defaultEventStreamSupervisionDecider}
 import org.zalando.kanadi.api._
 import org.zalando.kanadi.models._
 
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
+import scala.language.postfixOps
 import scala.util.Success
 
-class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with FutureMatchers with Config {
-  override def is: SpecStructure = sequential ^ s2"""
-    Create Event Type                            $createEventType
-    Create Subscription events                   $createSubscription
-    Start streaming and recover from noEmptySlot $startStreaming
-    """
+class NoEmptySlotsSpec
+    extends AsyncFreeTestKitSpec(ActorSystem("NoEmptySlotsSpec"))
+    with PekkoTestKitBase
+    with Matchers
+    with Config {
 
   val config = ConfigFactory.load()
 
-  implicit val system = ActorSystem()
-  implicit val http   = Http()
-
   val eventTypeName = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
 
-  eventTypeName.pp
+  pp(eventTypeName)
 
   val OwningApplication = "KANADI"
 
   val consumerGroup = UUID.randomUUID().toString
 
-  s"Consumer Group: $consumerGroup".pp
+  pp(s"Consumer Group: $consumerGroup")
 
   val subscriptionsClient =
     Subscriptions(nakadiUri, None)
@@ -46,10 +39,10 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
   val eventsTypesClient =
     EventTypes(nakadiUri, None)
 
-  def createEventType = (name: String) => {
+  "Create Event Type" in { () =>
     val future = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
 
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
+    future.map(_ => succeed)
   }
 
   val currentSubscriptionId: Promise[SubscriptionId] = Promise()
@@ -60,9 +53,9 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
   val modifySourceFunctionActivated: AtomicBoolean   = new AtomicBoolean(false)
   val streamComplete: Promise[Unit]                  = Promise()
 
-  def createSubscription = (name: String) => {
+  "Create Subscription events" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
     val future = subscriptionsClient.createIfDoesntExist(
       Subscription(
         None,
@@ -73,38 +66,18 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
 
     future.onComplete {
       case scala.util.Success(subscription) =>
-        subscription.id.pp
+        pp(subscription)
         currentSubscriptionId.complete(Success(subscription.id.get))
       case _ =>
     }
 
-    future.map(x => (x.owningApplication, x.eventTypes)) must beEqualTo((OwningApplication, Some(List(eventTypeName))))
-      .await(0, timeout = 5 seconds)
+    future.map(result =>
+      (result.owningApplication, result.eventTypes) mustEqual ((OwningApplication, Some(List(eventTypeName)))))
   }
 
-  def publishEvents = (name: String) => {
+  "Start streaming and recover from noEmptySlot" in { implicit td: TestData =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
-    val uUIDOne = java.util.UUID.randomUUID()
-    val uUIDTwo = java.util.UUID.randomUUID()
-
-    events = Some(
-      List(
-        SomeEvent("Robert", "Terwilliger", uUIDOne),
-        SomeEvent("Die", "Bart, Die", uUIDTwo)
-      ))
-
-    val future = eventsClient.publish[SomeEvent](
-      eventTypeName,
-      events.get.map(x => Event.Business(x))
-    )
-
-    future must be_==(()).await(retries = 3, timeout = 10 seconds)
-  }
-
-  def startStreaming = (name: String) => {
-    implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
 
     // Start stream One immediately
     val eventualStreamOne = for {
@@ -130,7 +103,7 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
                   )
       } yield stream
 
-    val future = for {
+    for {
       subscriptionId <- currentSubscriptionId.future
       streamId       <- eventualStreamOne
       _              <- org.apache.pekko.pattern.after(100 millis, system.scheduler)(Future.successful(()))
@@ -138,9 +111,7 @@ class NoEmptySlotsSpec(implicit ec: ExecutionEnv) extends Specification with Fut
       _              <- org.apache.pekko.pattern.after(100 millis, system.scheduler)(Future.successful(()))
       _               = subscriptionsClient.closeHttpConnection(subscriptionId, streamId)
       _              <- streamTwo
-    } yield ()
-
-    future must be_==(()).await(0, timeout = 4 minutes)
+    } yield succeed
 
   }
 }

--- a/src/test/scala/org/zalando/kanadi/PekkoTestKitBase.scala
+++ b/src/test/scala/org/zalando/kanadi/PekkoTestKitBase.scala
@@ -1,0 +1,33 @@
+package org.zalando.kanadi
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.{Http, HttpExt}
+import org.apache.pekko.testkit.{TestKit, TestKitBase}
+import org.scalactic.Prettifier
+import org.scalatest.{BeforeAndAfterAll, FixtureAsyncTestSuite, TestData, fixture}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+trait PekkoTestKitBase extends TestKitBase with BeforeAndAfterAll with fixture.AsyncTestDataFixture {
+  this: FixtureAsyncTestSuite =>
+  implicit val system: ActorSystem
+
+  implicit val http: HttpExt = Http()
+
+  override protected def afterAll(): Unit = {
+    val future = http.shutdownAllConnectionPools().map(_ => TestKit.shutdownActorSystem(system))(system.dispatcher)
+    Await.result(future, 10 seconds)
+  }
+
+  def pp(obj: Any)(implicit testData: TestData = null) = {
+    val string =
+      if (testData != null)
+        s"${testData.name}: ${Prettifier.default(obj)}"
+      else
+        Prettifier.default(obj)
+
+    println(string)
+  }
+}

--- a/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/SubscriptionsSpec.scala
@@ -2,28 +2,21 @@ package org.zalando.kanadi
 
 import java.util.UUID
 import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.Http
 import com.typesafe.config.ConfigFactory
-import org.specs2.Specification
-import org.specs2.concurrent.ExecutionEnv
-import org.specs2.specification.core.SpecStructure
-import org.specs2.specification.{AfterAll, BeforeAll}
+import org.scalatest.matchers.must.Matchers
 import org.zalando.kanadi.api.{Category, EventType, EventTypes, Events, Subscription, Subscriptions}
 import org.zalando.kanadi.models.{EventTypeName, FlowId, SubscriptionId}
 
 import scala.collection.parallel.mutable
-import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 
-class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Config with BeforeAll with AfterAll {
-  override def is: SpecStructure = sequential ^ s2"""
-      Create enough subscriptions to ensure that pagination is used $createEnoughSubscriptionsToUsePagination
-    """
+class SubscriptionsSpec
+    extends AsyncFreeTestKitSpec(ActorSystem("SubscriptionsSpec"))
+    with PekkoTestKitBase
+    with Matchers
+    with Config {
 
   val config = ConfigFactory.load()
-
-  implicit val system = ActorSystem()
-  implicit val http   = Http()
 
   val eventTypeName         = EventTypeName(s"Kanadi-Test-Event-${UUID.randomUUID().toString}")
   val OwningApplication     = "KANADI"
@@ -35,49 +28,31 @@ class SubscriptionsSpec(implicit ec: ExecutionEnv) extends Specification with Co
     EventTypes(nakadiUri, None)
   val subscriptionIds: mutable.ParSet[SubscriptionId] = mutable.ParSet.empty
 
-  eventTypeName.pp
-  s"Consumer Group: $consumerGroup".pp
+  pp(eventTypeName)
+  pp(s"Consumer Group: $consumerGroup")
 
-  def createEventType = eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
-
-  override def beforeAll =
-    Await.result(createEventType, 10 seconds)
-
-  override def afterAll = {
-    Await.result(
-      for {
-        res1 <- Future.sequence(subscriptionIds.toList.map(s => subscriptionsClient.delete(s)))
-        res2 <- eventsTypesClient.delete(eventTypeName)
-      } yield (res1, res2),
-      10 seconds
-    )
-    ()
-  }
-
-  def createEnoughSubscriptionsToUsePagination = (name: String) => {
+  "Create enough subscriptions to ensure that pagination is used" in { () =>
     implicit val flowId: FlowId = Utils.randomFlowId()
-    flowId.pp(name)
+    pp(flowId)
 
-    val createdSubscriptions = Future.sequence(for {
-      _ <- 1 to 22
-      subscription =
-        subscriptionsClient.create(
-          Subscription(None, s"$OwningApplication-${UUID.randomUUID().toString}", Some(List(eventTypeName))))
-    } yield {
-      subscription.foreach { s =>
-        subscriptionIds += s.id.get
-      }
-      subscription
-    })
-
-    val retrievedSubscriptions = (for {
-      subscriptions <- createdSubscriptions
-      retrievedSubscription = Future.sequence(subscriptions.map { subscription =>
-                                subscriptionsClient.createIfDoesntExist(subscription)
-                              })
-    } yield retrievedSubscription).flatMap(a => a)
-
-    Await.result(createdSubscriptions, 10 seconds) mustEqual Await.result(retrievedSubscriptions, 10 seconds)
+    for {
+      _ <- eventsTypesClient.create(EventType(eventTypeName, OwningApplication, Category.Business))
+      createdSubscriptions <-
+        Future.sequence(for {
+          _ <- 1 to 22
+          subscription =
+            subscriptionsClient.create(
+              Subscription(None, s"$OwningApplication-${UUID.randomUUID().toString}", Some(List(eventTypeName))))
+        } yield { /*  */
+          subscription.foreach { s =>
+            subscriptionIds += s.id.get
+          }
+          subscription
+        })
+      retrievedSubscription <- Future.sequence(createdSubscriptions.map { subscription =>
+                                 subscriptionsClient.createIfDoesntExist(subscription)
+                               })
+    } yield createdSubscriptions mustEqual retrievedSubscription
   }
 
 }

--- a/src/test/scala/org/zalando/kanadi/URIDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/URIDecodingSpec.scala
@@ -2,31 +2,29 @@ package org.zalando.kanadi
 
 import java.net.URI
 import io.circe.syntax._
-import org.specs2.Specification
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
 
-class URIDecodingSpec extends Specification {
-  override def is = s2"""
-      Encode and decode an absolute URI $absoluteURI
-      Encode and decode a relative URI $relativeURI
-      """
+class URIDecodingSpec extends AnyFreeSpec with Matchers with EitherValues {
 
-  def absoluteURI = {
+  "Encode and decode an absolute URI" in {
     val absoluteLink = "https://www.google.de/search?q=nyancat"
 
     val uri     = new URI(absoluteLink)
     val uriJson = uri.asJson
     val result  = uriJson.as[URI]
 
-    result must beRight(uri)
+    result.value mustEqual uri
   }
 
-  def relativeURI = {
+  "Encode and decode a relative URI" in {
     val relativeLink = "/doggos?size=puppy"
 
     val uri     = new URI(relativeLink)
     val uriJson = uri.asJson
     val result  = uriJson.as[URI]
 
-    result must beRight(uri)
+    result.value mustEqual uri
   }
 }

--- a/src/test/scala/org/zalando/kanadi/models/codec/ProblemCodecSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/models/codec/ProblemCodecSpec.scala
@@ -1,22 +1,15 @@
 package org.zalando.kanadi.models.codec
 
 import io.circe.parser._
-import org.specs2.Specification
-import org.specs2.matcher.MatchResult
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
 import org.zalando.kanadi.models.Problem
 
 import java.net.URI
 
-final class ProblemCodecSpec extends Specification {
+final class ProblemCodecSpec extends AnyFreeSpec with Matchers with EitherValues {
   import ProblemCodec._
-
-  def is =
-    s2"""
-    decode problemA as $decodeProblemA
-    decode problemB as $decodeProblemB
-    decode problemC as $decodeProblemC
-    decode problemD as $decodeProblemD
-  """
 
   private val problemAstr =
     """{"title":"Forbidden","status":403,"detail":"Access on READ subscription:e1eeeb6d-1819-48de-924e-ded2fe983c9e denied"}"""
@@ -57,7 +50,7 @@ final class ProblemCodecSpec extends Specification {
     instance = None
   )
 
-  def decodeProblemA: String => MatchResult[Either[Throwable, Problem]] = (name: String) => {
+  "decode problemA" in {
     val expected = problemA
     val actual =
       for {
@@ -65,10 +58,10 @@ final class ProblemCodecSpec extends Specification {
         problem <- parsed.as[Problem]
       } yield problem
 
-    actual must beRight(expected)
+    actual.value mustEqual expected
   }
 
-  def decodeProblemB: String => MatchResult[Either[Throwable, Problem]] = (name: String) => {
+  "decode problemB as" in {
     val expected = problemB
     val actual =
       for {
@@ -76,10 +69,10 @@ final class ProblemCodecSpec extends Specification {
         problem <- parsed.as[Problem]
       } yield problem
 
-    actual must beRight(expected)
+    actual.value mustEqual expected
   }
 
-  def decodeProblemC: String => MatchResult[Either[Throwable, Problem]] = (name: String) => {
+  "decode problemC as" in {
     val expected = problemC
     val actual =
       for {
@@ -87,10 +80,10 @@ final class ProblemCodecSpec extends Specification {
         problem <- parsed.as[Problem]
       } yield problem
 
-    actual must beRight(expected)
+    actual.value mustEqual expected
   }
 
-  def decodeProblemD: String => MatchResult[Either[Throwable, Problem]] = (name: String) => {
+  "decode problemD as" in {
     val expected = problemD
     val actual =
       for {
@@ -98,6 +91,6 @@ final class ProblemCodecSpec extends Specification {
         problem <- parsed.as[Problem]
       } yield problem
 
-    actual must beRight(expected)
+    actual.value mustEqual expected
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/zalando-nakadi/kanadi/issues/135
Resolves: https://github.com/zalando-nakadi/kanadi/issues/207

This PR replaces specs2 with scalatest which provides the following benefits

* Pekko has integrations with scalatest which allows a principled way of setting up tests that uses actors as well as properly cleaning up Actorsystem/pekko-http resources
* ScalaTest is much better maintained than specs2 and supports Scala 3
* ScalaTest has a concept of fixtures, while its currently use to pass the test name when doing `pp` it can be extended to do things like auto generate a flowId (even further reducing the boilerplate of current tests)
* Can properly test against futures without having to do blocking calls (this is why assertions in scalatest on futures can be placed inside of `.map`)
* Has integrations with [testcontainers-scala](https://github.com/testcontainers/testcontainers-scala) which can be used to autostart our Nakadi docker container whenever a test, even via Intellij's test runner

I have done some minor improvements but in general I have preferenced minimizing the diff rather than doing more idiomatic improvements (which can be done in future PR's)