### PR TITLE
Cleanup compiler warnings and flags

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,8 +33,7 @@ object Settings {
     "-language:implicitConversions", // Allow definition of implicit functions called views
     "-unchecked",                    // Enable additional warnings where generated code depends on assumptions.
     "-Xcheckinit",                   // Wrap field accessors to throw an exception on uninitialized access.
-    //  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-    "-Xfuture",                      // Turn on future language features.
+    "-Xfatal-warnings",              // Fail the compilation if there are any warnings.
     "-Xlint:adapted-args",           // Warn if an argument list is modified to match the receiver.
     "-Xlint:delayedinit-select",     // Selecting member of DelayedInit.
     "-Xlint:doc-detached",           // A Scaladoc comment appears to be detached from its element.
@@ -63,6 +62,7 @@ object Settings {
     "-Ywarn-infer-any",                 // Warn when a type argument is inferred to be `Any`.
     "-Xlint:nullary-override",          // Warn when non-nullary `def f()' overrides nullary `def f'.
     "-Xlint:nullary-unit",              // Warn when nullary methods return Unit.
+    "-Xfuture",                         // Turn on future language features.
     "-opt:l:inline",
     "-opt-inline-from:<sources>"
   )
@@ -70,7 +70,8 @@ object Settings {
   private val scalacOptionsFor13 = Seq(
     "-Xlint:_",
     "-opt:l:inline",
-    "-opt-inline-from:<sources>"
+    "-opt-inline-from:<sources>",
+    "-Xlint:-byname-implicit" // See https://github.com/scala/bug/issues/12072#issuecomment-884514638
   )
 
   val sharedResolvers: Vector[MavenRepository] =

--- a/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
@@ -95,7 +95,7 @@ class BadJsonDecodingSpec
       (result.owningApplication, result.eventTypes) mustEqual ((OwningApplication, Some(List(eventTypeName)))))
   }
 
-  implicit val mySupervisionDecider =
+  implicit val mySupervisionDecider: Subscriptions.EventStreamSupervisionDecider =
     Subscriptions.EventStreamSupervisionDecider { eventStreamContext: EventStreamContext =>
       {
         case parsingException: Subscriptions.EventJsonParsingException =>

--- a/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/NoEmptySlotsSpec.scala
@@ -84,9 +84,8 @@ class NoEmptySlotsSpec
       subscriptionId <- currentSubscriptionId.future
       stream <- subscriptionsClient.eventsStreamedManaged[SomeEvent](
                   subscriptionId,
-                  EventCallback.successAlways { eventCallbackData =>
-                    eventCallbackData.subscriptionEvent.events
-                      .getOrElse(List.empty)
+                  EventCallback.successAlways { _ =>
+                    ()
                   }
                 )
     } yield stream
@@ -96,9 +95,8 @@ class NoEmptySlotsSpec
         subscriptionId <- currentSubscriptionId.future
         stream <- subscriptionsClient.eventsStreamedManaged[SomeEvent](
                     subscriptionId,
-                    EventCallback.successAlways { eventCallbackData =>
-                      eventCallbackData.subscriptionEvent.events
-                        .getOrElse(List.empty)
+                    EventCallback.successAlways { _ =>
+                      ()
                     }
                   )
       } yield stream

--- a/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
+++ b/src/test/scala/org/zalando/kanadi/api/EventPublishRetrySpec.scala
@@ -146,7 +146,7 @@ class EventPublishRetrySpec
       }
     }
 
-  implicit val flowId = FlowId(UUID.randomUUID().toString)
+  implicit val flowId: FlowId = FlowId(UUID.randomUUID().toString)
 
   "Failed partial events are successfully retried" in { () =>
     val future = for {


### PR DESCRIPTION
Alsi in preparation for Scala 3 since the flags/warnings are different/strict there so its easier to deal with if we handle the warnings for the other Scala versions better