### PR TITLE
Log occurred exception even if it doesn't have cause

### DIFF
--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1469,7 +1469,7 @@ case class Subscriptions(baseUri: URI, authTokenProvider: Option[AuthTokenProvid
       .recoverWith { case NonFatal(e) =>
         logger.info(
           s"Reconnecting failed, retry again in ${reconnectDelay.toString()}, SubscriptionId: ${subscriptionId.id.toString}",
-          e.getCause
+          e
         )
         reconnect(subscriptionId,
                   eventCallback,

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1467,7 +1467,7 @@ case class Subscriptions(baseUri: URI, authTokenProvider: Option[AuthTokenProvid
           modifySourceFunction
         ))
       .recoverWith { case NonFatal(e) =>
-        logger.info(
+        logger.warn(
           s"Reconnecting failed, retry again in ${reconnectDelay.toString()}, SubscriptionId: ${subscriptionId.id.toString}",
           e
         )


### PR DESCRIPTION
I have a problem in my application where it cannot reconnect to Nakadi and I can't figure out why, because exception is not logged, apparently, because the occurring exception doesn't have a cause:

`Reconnecting failed, retry again in 10 seconds, SubscriptionId: <uuid>'`
