### PR TITLE
Update scalafmt version and GitHub action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,4 @@ jobs:
           fetch-depth: 0
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@v2
-        with:
-          version: '3.1.2'
+        uses: jrouly/scalafmt-native-action@v3

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.1.2
+version = 3.7.17
 runner.dialect = scala212source3
 style = defaultWithAlign
 maxColumn = 120

--- a/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
+++ b/src/main/scala/org/zalando/kanadi/api/Subscriptions.scala
@@ -1533,7 +1533,7 @@ case class Subscriptions(baseUri: URI, authTokenProvider: Option[AuthTokenProvid
       Subscriptions.ConnectionClosedCallback { connectionClosedData =>
         if (!connectionClosedData.cancelledByClient) {
           logger.info(s"Server disconnected Nakadi stream, reconnecting in ${kanadiHttpConfig.serverDisconnectRetryDelay
-            .toString()}. Old StreamId: ${connectionClosedData.oldStreamId.id}, SubscriptionId: ${subscriptionId.id.toString}")
+              .toString()}. Old StreamId: ${connectionClosedData.oldStreamId.id}, SubscriptionId: ${subscriptionId.id.toString}")
 
           reconnect(subscriptionId,
                     eventCallback,
@@ -1555,7 +1555,7 @@ case class Subscriptions(baseUri: URI, authTokenProvider: Option[AuthTokenProvid
       streamId
     }.recoverWith { case _: Subscriptions.Errors.NoEmptySlotsOrCursorReset =>
       logger.info(s"No empty slots/cursor reset, reconnecting in ${kanadiHttpConfig.noEmptySlotsCursorResetRetryDelay
-        .toString()}, SubscriptionId: ${subscriptionId.id.toString}")
+          .toString()}, SubscriptionId: ${subscriptionId.id.toString}")
 
       reconnect(subscriptionId,
                 eventCallback,
@@ -1586,7 +1586,7 @@ case class Subscriptions(baseUri: URI, authTokenProvider: Option[AuthTokenProvid
       nakadiSource
     }.recoverWith { case _: Subscriptions.Errors.NoEmptySlotsOrCursorReset =>
       logger.info(s"No empty slots/cursor reset, reconnecting in ${kanadiHttpConfig.noEmptySlotsCursorResetRetryDelay
-        .toString()}, SubscriptionId: ${subscriptionId.id.toString}")
+          .toString()}, SubscriptionId: ${subscriptionId.id.toString}")
       org.apache.pekko.pattern.after(kanadiHttpConfig.noEmptySlotsCursorResetRetryDelay, http.system.scheduler)(
         eventsStreamedSourceManaged[T](
           subscriptionId,

--- a/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
+++ b/src/test/scala/org/zalando/kanadi/BadJsonDecodingSpec.scala
@@ -178,7 +178,7 @@ class BadJsonDecodingSpec
     val future = for {
       closed       <- closedFuture
       waitForClose <- waitForCloseFuture
-    } yield (closed | waitForClose) // either connection has been closed earlier or from our client side
+    } yield closed | waitForClose // either connection has been closed earlier or from our client side
 
     future.map(result => result mustEqual true)
   }


### PR DESCRIPTION
This PR does the following

* Updates the scalafmt version to latest
* Applies scalafmt bringing in formatting improvements from the update (done in a separate commit to keep it clear)
* Updates the scalafmt- native-action to `v3` which has contains the improvement where you no longer need to specify the scalafmt version twice (i.e. it now only needs to be specified in `.scalafmt.conf`)